### PR TITLE
fix: repair context shift, KV cache reuse and Predict buffer overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ fmt.Printf("Parameters: %d\n", info.NParams)
 fmt.Printf("Size: %d bytes\n", info.Size)
 
 // Get chat template for chat models
-template := model.GetChatTemplate()
+// Pass "" for the default template, or a name for a specific one
+template := model.GetChatTemplate("")
 ```
 
 ### All Sampling Options
@@ -285,11 +286,16 @@ model.Predict("Write a story about a robot:",
 ### Embeddings
 
 ```go
-model, _ := llama.New("model.gguf", llama.EnableEmbeddings())
+model, _ := llama.New("model.gguf", llama.EnableEmbeddings)
 
 embeddings, _ := model.Embeddings("The quick brown fox")
 fmt.Printf("Vector dimension: %d\n", len(embeddings))
 ```
+
+> **Note:** A model loaded with `EnableEmbeddings` cannot generate text. The context
+> returns pooled embeddings instead of token logits, so `Predict` produces garbage
+> output. If you need both, load the model twice — once with `EnableEmbeddings` and
+> once without.
 
 ### With LoRA Adapter
 

--- a/binding.cpp
+++ b/binding.cpp
@@ -7,6 +7,7 @@
 
 #include "binding.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cinttypes>
 #include <cmath>
@@ -146,15 +147,19 @@ int get_embeddings(void* params_ptr, void* state_pr, float * res_embeddings) {
         return 1;
     }
     
+    // Each call embeds its own prompt, so drop the cells left by earlier calls.
+    // Without this the context fills up and llama_decode runs out of slots.
+    llama_memory_seq_rm(llama_get_memory(ctx), -1, -1, -1);
+
     // Create batch
     llama_batch batch = llama_batch_get_one(tokens.data(), tokens.size());
-    
+
     // Decode
     if (llama_decode(ctx, batch) != 0) {
         fprintf(stderr, "%s: failed to decode\n", __func__);
         return 1;
     }
-    
+
     const int n_embd = llama_model_n_embd(model);
     const float * embeddings = llama_get_embeddings(ctx);
     
@@ -186,15 +191,22 @@ int get_token_embeddings(void* params_ptr, void* state_pr, int *tokens, int toke
     return get_embeddings(params_ptr, state_pr, res_embeddings);
 }
 
-int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
+int llama_predict(void* params_ptr, void* state_pr, char* result, int result_size, bool debug) {
     binding_params* params_p = (binding_params*) params_ptr;
     llama_binding_state* state = (llama_binding_state*) state_pr;
     llama_context* ctx = state->ctx;
     llama_model* model = state->model;
     const llama_vocab * vocab = llama_model_get_vocab(model);
-    
+    llama_memory_t mem = llama_get_memory(ctx);
+
     const int n_ctx = llama_n_ctx(ctx);
-    
+
+    // Each prediction starts from a clean cache: n_past below counts from zero,
+    // so cells left over from an earlier call would both desync the position
+    // bookkeeping and fill up the context. Use save_state/load_state to carry
+    // state across calls on purpose.
+    llama_memory_seq_rm(mem, -1, -1, -1);
+
     // Set seed if specified
     if (params_p->seed != LLAMA_DEFAULT_SEED) {
         // Seed is now set during sampler initialization
@@ -306,23 +318,39 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
     
     std::string res = "";
     std::vector<llama_token> embd;
-    
+
     int n_past = 0;
     int n_remain = params_p->n_predict;
     int n_consumed = 0;
-    
+
+    // Tokens kept in front of the context when it has to be shifted. It can
+    // never exceed the prompt, otherwise the shift would discard tokens that
+    // were never there.
+    const int n_keep = std::min(std::max(params_p->n_keep, 0), (int) embd_inp.size());
+
     bool is_antiprompt = false;
-    
+
     while (n_remain != 0) {
         // Process tokens
         if (!embd.empty()) {
-            // Check context overflow
+            // Context is full: discard the oldest half of the tokens after
+            // n_keep and move the rest down, so the cache has free cells again.
             if (n_past + (int) embd.size() > n_ctx) {
-                const int n_left = n_past - params_p->n_keep;
-                n_past = std::max(1, params_p->n_keep);
-                embd.insert(embd.begin(), embd_inp.begin() + params_p->n_keep, embd_inp.begin() + params_p->n_keep + n_left/2);
+                const int n_discard = (n_past - n_keep) / 2;
+
+                if (n_discard <= 0 || n_keep + (int) embd.size() > n_ctx) {
+                    fprintf(stderr, "%s: error: context too small to shift (n_ctx = %d, n_keep = %d)\n",
+                            __func__, n_ctx, n_keep);
+                    llama_sampler_free(smpl);
+                    return 1;
+                }
+
+                llama_memory_seq_rm (mem, 0, n_keep, n_keep + n_discard);
+                llama_memory_seq_add(mem, 0, n_keep + n_discard, n_past, -n_discard);
+
+                n_past -= n_discard;
             }
-            
+
             // Create batch and decode
             for (int i = 0; i < (int) embd.size(); i += params_p->n_batch) {
                 int n_eval = (int) embd.size() - i;
@@ -398,8 +426,12 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug) {
     }
     
     llama_sampler_free(smpl);
-    
-    strcpy(result, res.c_str());
+
+    // Bounded copy: a token decodes to several bytes, so `res` is routinely
+    // longer than the caller's token limit. Truncate instead of overrunning.
+    if (result_size > 0) {
+        snprintf(result, (size_t) result_size, "%s", res.c_str());
+    }
     return 0;
 }
 

--- a/binding.h
+++ b/binding.h
@@ -54,7 +54,7 @@ void llama_binding_free_model(void* state);
 
 int llama_tokenize_string(void* params_ptr, void* state_pr, int* result);
 
-int llama_predict(void* params_ptr, void* state_pr, char* result, bool debug);
+int llama_predict(void* params_ptr, void* state_pr, char* result, int result_size, bool debug);
 
 // Model info functions
 int get_model_n_vocab(void* state_ptr);

--- a/examples/main.go
+++ b/examples/main.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	threads   = 4
-	tokens    = 128
-	gpulayers = 0
-	seed      = -1
+	threads     = 4
+	tokens      = 512
+	gpulayers   = 0
+	seed        = -1
+	contextSize = 4096
 )
 
 func main() {
@@ -27,6 +28,7 @@ func main() {
 	flags.IntVar(&gpulayers, "ngl", 0, "Number of GPU layers to use")
 	flags.IntVar(&threads, "t", runtime.NumCPU(), "number of threads to use during computation")
 	flags.IntVar(&tokens, "n", 512, "number of tokens to predict")
+	flags.IntVar(&contextSize, "c", 4096, "context size in tokens")
 	flags.IntVar(&seed, "s", -1, "predict RNG seed, -1 for random seed")
 
 	err := flags.Parse(os.Args[1:])
@@ -34,11 +36,21 @@ func main() {
 		fmt.Printf("Parsing program arguments failed: %s", err)
 		os.Exit(1)
 	}
-	l, err := llama.New(model, llama.EnableF16Memory, llama.SetContext(128), llama.EnableEmbeddings, llama.SetGPULayers(gpulayers))
+
+	// The context has to hold the prompt plus everything we generate. Do not
+	// enable embeddings here: an embeddings context returns pooled vectors
+	// instead of token logits, which turns generation into garbage. Load the
+	// model a second time with llama.EnableEmbeddings if you need both.
+	l, err := llama.New(model,
+		llama.SetContext(contextSize),
+		llama.SetGPULayers(gpulayers),
+	)
 	if err != nil {
 		fmt.Println("Loading the model failed:", err.Error())
 		os.Exit(1)
 	}
+	defer l.Free()
+
 	fmt.Printf("Model loaded successfully.\n")
 
 	reader := bufio.NewReader(os.Stdin)
@@ -49,15 +61,11 @@ func main() {
 		_, err := l.Predict(text, llama.Debug, llama.SetTokenCallback(func(token string) bool {
 			fmt.Print(token)
 			return true
-		}), llama.SetTokens(tokens), llama.SetThreads(threads), llama.SetTopK(90), llama.SetTopP(0.86), llama.SetStopWords("llama"), llama.SetSeed(seed))
+		}), llama.SetTokens(tokens), llama.SetThreads(threads), llama.SetTopK(40), llama.SetTopP(0.9), llama.SetTemperature(0.7), llama.SetSeed(seed))
 		if err != nil {
-			panic(err)
+			fmt.Printf("Predicting failed: %s\n", err)
+			os.Exit(1)
 		}
-		embeds, err := l.Embeddings(text)
-		if err != nil {
-			fmt.Printf("Embeddings: error %s \n", err.Error())
-		}
-		fmt.Printf("Embeddings: %v", embeds)
 		fmt.Printf("\n\n")
 	}
 }

--- a/llama.go
+++ b/llama.go
@@ -16,6 +16,17 @@ import (
 	"unsafe"
 )
 
+const (
+	// bytesPerTokenEstimate is a generous upper bound on the UTF-8 length of a
+	// single decoded token, used to size the Predict output buffer.
+	bytesPerTokenEstimate = 8
+
+	// maxPredictBytes caps that buffer so an unbounded token limit does not ask
+	// for a huge allocation. Output beyond it is truncated; use
+	// SetTokenCallback to stream longer generations.
+	maxPredictBytes = 4 * 1024 * 1024
+)
+
 type LLama struct {
 	state       unsafe.Pointer
 	embeddings  bool
@@ -290,7 +301,15 @@ func (l *LLama) Predict(text string, opts ...PredictOption) (string, error) {
 	if po.Tokens == 0 {
 		po.Tokens = 99999999
 	}
-	out := make([]byte, po.Tokens)
+
+	// A token decodes to several bytes, so the output buffer has to be larger
+	// than the token count. The C side truncates to the size we pass, so this
+	// is a hard bound rather than a guess that could overrun.
+	outSize := po.Tokens*bytesPerTokenEstimate + len(text) + 1024
+	if outSize > maxPredictBytes || outSize < 0 {
+		outSize = maxPredictBytes
+	}
+	out := make([]byte, outSize)
 
 	reverseCount := len(po.StopPrompts)
 	reversePrompt := make([]*C.char, reverseCount)
@@ -317,7 +336,7 @@ func (l *LLama) Predict(text string, opts ...PredictOption) (string, error) {
 		C.float(po.DRYMultiplier), C.float(po.DRYBase), C.int(po.DRYAllowedLength), C.int(po.DRYPenaltyLastN),
 		C.float(po.TopNSigma),
 	)
-	ret := C.llama_predict(params, l.state, (*C.char)(unsafe.Pointer(&out[0])), C.bool(po.DebugMode))
+	ret := C.llama_predict(params, l.state, (*C.char)(unsafe.Pointer(&out[0])), C.int(len(out)), C.bool(po.DebugMode))
 	if ret != 0 {
 		return "", fmt.Errorf("inference failed")
 	}


### PR DESCRIPTION
Fixes #172.

## The reported bug

The context-shift branch in `llama_predict` never freed any KV cells. It rewrote the token vector but left the cache full, so `llama_decode` had no slot for the next batch:

```
decode: failed to find a memory slot for batch of size 97
llama_predict: failed to decode
```

It also read `embd_inp.begin() + n_keep` with the default `n_keep` of 64, which is out of bounds for any shorter prompt — that is where the odd batch size of 97 came from.

Replaced with the standard `llama_memory_seq_rm` + `llama_memory_seq_add` shift, with `n_keep` clamped to the prompt length and an explicit error when the context is too small to shift at all.

## Related fixes

**Stale KV cache between calls.** `llama_predict` and `get_embeddings` now clear the cache on entry. `n_past` counts from zero on every call, but cells from the previous call were still present, so positions desynced and the context filled up over a few turns — reaching the same decode failure even with a large context. Callers who want to carry state across calls should use `save_state` / `load_state`.

**Heap overflow in `Predict`.** `llama_predict` ended with `strcpy(result, res.c_str())` into a buffer that `llama.go` sized at one byte per token. 512 tokens of English is roughly 2 KB going into a 512-byte allocation. The function now takes a `result_size` and truncates; Go sizes the buffer with a bytes-per-token estimate capped at 4 MB.

**The example.** It loaded the model with `EnableEmbeddings`, which makes the context return pooled embeddings instead of token logits, so sampling read invalid data and printed garbage (`0.1.0.1.0.1...`). Dropped it, raised the context from 128 to 4096, added a `-c` flag, added `defer l.Free()`, and replaced the `SetStopWords("llama")` / `TopK(90)` defaults with normal sampling values.

**README.** `GetChatTemplate` takes a name argument, `EnableEmbeddings` is a var rather than a function, and an embeddings context cannot generate text.

## Verification

- `g++ -fsyntax-only -std=c++17` on `binding.cpp` — clean apart from pre-existing warnings
- `go build .` — succeeds
- `go vet ./examples`, `gofmt -l .` — clean

Not run: inference against a real model. That needs a full `make libbinding.a` plus a GGUF file, which I could not do here. Worth a manual smoke test before merging — a prompt that generates past the context size is the case to check.

## Known issue left out of scope

`get_embeddings` reads `llama_get_embeddings(ctx)`, which returns the unpooled per-token buffer. Models that resolve to MEAN or CLS pooling need `llama_get_embeddings_seq`, so `Embeddings()` likely returns the wrong vector today. Separate change.
