### PR TITLE
fix: bump llama.cpp to 8f5ab83 and migrate to load_mode API

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -24,8 +24,12 @@
 #include <signal.h>
 #include <unistd.h>
 #elif defined (_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <signal.h>
 #endif
@@ -207,11 +211,9 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
     // state across calls on purpose.
     llama_memory_seq_rm(mem, -1, -1, -1);
 
-    // Set seed if specified
-    if (params_p->seed != LLAMA_DEFAULT_SEED) {
-        // Seed is now set during sampler initialization
-    }
-    
+    // Note: the RNG seed is applied when the sampler chain is built below
+    // (llama_sampler_init_dist / mirostat), not on the context.
+
     // Tokenize prompt
     bool add_bos = llama_vocab_get_add_bos(vocab);
     std::vector<llama_token> embd_inp = tokenize_prompt(vocab, params_p->prompt, add_bos);
@@ -382,7 +384,7 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
             
             // Get token string and callback
             std::string token_str = token_to_piece(vocab, id);
-            if (!tokenCallback(state_pr, (char*)token_str.c_str())) {
+            if (!tokenCallback(state_pr, &token_str[0])) {
                 break;
             }
             
@@ -621,7 +623,16 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
                  bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch, 
                  const char *maingpu, const char *tensorsplit, bool numa, float rope_freq_base, 
                  float rope_freq_scale, const char *lora, const char *lora_base) {
-    
+
+    // These parameters are retained for C ABI stability with the Go layer but
+    // are no longer consumed by llama.cpp: the seed is applied when the sampler
+    // chain is built, KV-cache precision is chosen via the context params, and
+    // low_vram / lora_base were removed from the upstream API.
+    (void) n_seed;
+    (void) memory_f16;
+    (void) low_vram;
+    (void) lora_base;
+
     fprintf(stderr, "%s: loading model from '%s'\n", __func__, fname);
     
     // Initialize backend
@@ -634,8 +645,13 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
     // Setup model parameters
     llama_model_params model_params = llama_model_default_params();
     model_params.n_gpu_layers = n_gpu_layers;
-    model_params.use_mmap = mmap;
-    model_params.use_mlock = mlock;
+    // llama.cpp replaced the use_mmap/use_mlock booleans with a single
+    // load_mode enum. Preserve the binding's semantics: mlock implies mmap
+    // (LLAMA_LOAD_MODE_MLOCK == "mmap + keep resident"), a plain mmap request
+    // maps to LLAMA_LOAD_MODE_MMAP, and neither maps to LLAMA_LOAD_MODE_NONE.
+    model_params.load_mode = mlock ? LLAMA_LOAD_MODE_MLOCK
+                           : mmap  ? LLAMA_LOAD_MODE_MMAP
+                                   : LLAMA_LOAD_MODE_NONE;
     
     // Parse main GPU
     if (maingpu != nullptr && maingpu[0] != '\0') {


### PR DESCRIPTION
## What & why

Bumps the `llama.cpp` submodule `76f46ad → 8f5ab83` and repairs the binding for the upstream API change that broke the build.

At `8f5ab83`, llama.cpp replaced the `use_mmap` / `use_mlock` booleans in `llama_model_params` with a single `load_mode` enum (`LLAMA_LOAD_MODE_NONE/MMAP/MLOCK/DIRECT_IO`). `binding.cpp` still assigned the removed fields, so every `stable` CI job failed with:

```
binding.cpp:637:18: error: 'struct llama_model_params' has no member named 'use_mmap'
binding.cpp:638:18: error: 'struct llama_model_params' has no member named 'use_mlock'
```

## Changes

- **`load_model`**: map the binding's `mmap`/`mlock` booleans onto `load_mode`, preserving prior defaults (`MMap=true, MLock=false → LLAMA_LOAD_MODE_MMAP`). `mlock` implies mmap, matching the enum's semantics.
- **Warning cleanup** (surfaced by the bump): const-cast in the token callback → `&token_str[0]`; removed a dead seed conditional (also fixed a sign-compare warning); acknowledged the legacy `load_model` params that upstream no longer consumes (`n_seed`, `memory_f16`, `low_vram`, `lora_base`); guarded the Windows `NOMINMAX`/`WIN32_LEAN_AND_MEAN` defines.

The fix is **C++-only and ABI-stable** — the C signature in `binding.h` and the Go layer are unchanged, so no behavioral change beyond the load-mode mapping.

## Verification

`binding.cpp` compiles clean against the `8f5ab83` headers with the project's flags — zero errors, zero warnings:

```
g++ -I./llama.cpp -I./llama.cpp/include -I./llama.cpp/ggml/include -I. -I./llama.cpp/common \
    -std=c++17 -fPIC -Wall -Wextra -Wpedantic -Wcast-qual -Wno-unused-function -fsyntax-only binding.cpp
```

## Supersedes

Closes #177 (dependabot submodule bump), which carried the same version bump but failed CI without this binding change.