### PR TITLE
feat: model introspection, GGUF metadata, and backend capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,16 +160,33 @@ llama.SetTopNSigma(n float64)
 // Get comprehensive model metadata
 info := model.GetModelInfo()
 fmt.Printf("Model: %s\n", info.Description)
-fmt.Printf("Vocabulary: %d tokens\n", info.NVocab)
-fmt.Printf("Context Length: %d\n", info.NCtxTrain)
-fmt.Printf("Embedding Dim: %d\n", info.NEmbd)
-fmt.Printf("Layers: %d\n", info.NLayer)
-fmt.Printf("Parameters: %d\n", info.NParams)
-fmt.Printf("Size: %d bytes\n", info.Size)
+fmt.Printf("Vocabulary: %d tokens\n", info.VocabSize)
+fmt.Printf("Context Length: %d\n", info.ContextLength)
+fmt.Printf("Embedding Dim: %d\n", info.EmbeddingSize)
+fmt.Printf("Layers: %d\n", info.LayerCount)
+fmt.Printf("Attention Heads: %d (KV: %d)\n", info.HeadCount, info.HeadCountKV)
+fmt.Printf("Parameters: %d\n", info.ParamCount)
+fmt.Printf("Size: %d bytes\n", info.ModelSize)
+
+// Read the raw GGUF key-value metadata header
+meta := model.ModelMetadata()
+fmt.Printf("Architecture: %s\n", meta["general.architecture"])
+if name, ok := model.ModelMetadataValue("general.name"); ok {
+    fmt.Printf("Name: %s\n", name)
+}
+
+// Special tokens, including PAD, MASK and fill-in-the-middle
+tokens := model.GetSpecialTokens()
+fmt.Printf("BOS=%d EOS=%d EOT=%d FIMPre=%d\n", tokens.BOS, tokens.EOS, tokens.EOT, tokens.FIMPre)
 
 // Get chat template for chat models
 // Pass "" for the default template, or a name for a specific one
 template := model.GetChatTemplate("")
+
+// Backend capabilities — these need no loaded model
+fmt.Printf("mmap=%v mlock=%v gpuOffload=%v maxDevices=%d\n",
+    llama.SupportsMmap(), llama.SupportsMlock(),
+    llama.SupportsGPUOffload(), llama.MaxDevices())
 ```
 
 ### All Sampling Options

--- a/binding.cpp
+++ b/binding.cpp
@@ -772,6 +772,48 @@ int get_model_chat_template(void* state_ptr, const char* name, char* buf, int bu
     return len;
 }
 
+// Extended model geometry
+int get_model_n_head(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_n_head(state->model);
+}
+
+int get_model_n_head_kv(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_n_head_kv(state->model);
+}
+
+int get_model_n_swa(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_n_swa(state->model);
+}
+
+float get_model_rope_freq_scale_train(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_rope_freq_scale_train(state->model);
+}
+
+// Model metadata (GGUF key-value header)
+int get_model_meta_count(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_meta_count(state->model);
+}
+
+int get_model_meta_val_str(void* state_ptr, const char* key, char* buf, int buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_meta_val_str(state->model, key, buf, (size_t) buf_size);
+}
+
+int get_model_meta_key_by_index(void* state_ptr, int i, char* buf, int buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_meta_key_by_index(state->model, i, buf, (size_t) buf_size);
+}
+
+int get_model_meta_val_str_by_index(void* state_ptr, int i, char* buf, int buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_meta_val_str_by_index(state->model, i, buf, (size_t) buf_size);
+}
+
 // Special token functions
 int get_vocab_bos(void* state_ptr) {
     llama_binding_state* state = (llama_binding_state*) state_ptr;
@@ -815,6 +857,47 @@ bool get_vocab_add_eos(void* state_ptr) {
     return llama_vocab_get_add_eos(vocab);
 }
 
+// Extended special tokens (padding, mask, fill-in-the-middle)
+int get_vocab_pad(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_pad(llama_model_get_vocab(state->model));
+}
+
+int get_vocab_mask(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_mask(llama_model_get_vocab(state->model));
+}
+
+int get_vocab_fim_pre(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_fim_pre(llama_model_get_vocab(state->model));
+}
+
+int get_vocab_fim_suf(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_fim_suf(llama_model_get_vocab(state->model));
+}
+
+int get_vocab_fim_mid(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_fim_mid(llama_model_get_vocab(state->model));
+}
+
+int get_vocab_fim_pad(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_fim_pad(llama_model_get_vocab(state->model));
+}
+
+int get_vocab_fim_rep(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_fim_rep(llama_model_get_vocab(state->model));
+}
+
+int get_vocab_fim_sep(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_fim_sep(llama_model_get_vocab(state->model));
+}
+
 // Model architecture queries
 bool model_has_encoder(void* state_ptr) {
     llama_binding_state* state = (llama_binding_state*) state_ptr;
@@ -845,6 +928,14 @@ int get_system_info(char* buf, int buf_size) {
     buf[len] = '\0';
     return len;
 }
+
+// Backend capability queries (no model required)
+bool backend_supports_mmap(void)          { return llama_supports_mmap(); }
+bool backend_supports_mlock(void)         { return llama_supports_mlock(); }
+bool backend_supports_gpu_offload(void)   { return llama_supports_gpu_offload(); }
+bool backend_supports_rpc(void)           { return llama_supports_rpc(); }
+int  backend_max_devices(void)            { return (int) llama_max_devices(); }
+int  backend_max_parallel_sequences(void) { return (int) llama_max_parallel_sequences(); }
 
 int apply_chat_template(void* state_ptr, const char* tmpl, const char* messages_json,
                         bool add_generation_prompt, char* result, int result_size) {

--- a/binding.cpp
+++ b/binding.cpp
@@ -24,8 +24,12 @@
 #include <signal.h>
 #include <unistd.h>
 #elif defined (_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <signal.h>
 #endif
@@ -207,11 +211,9 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
     // state across calls on purpose.
     llama_memory_seq_rm(mem, -1, -1, -1);
 
-    // Set seed if specified
-    if (params_p->seed != LLAMA_DEFAULT_SEED) {
-        // Seed is now set during sampler initialization
-    }
-    
+    // Note: the RNG seed is applied when the sampler chain is built below
+    // (llama_sampler_init_dist / mirostat), not on the context.
+
     // Tokenize prompt
     bool add_bos = llama_vocab_get_add_bos(vocab);
     std::vector<llama_token> embd_inp = tokenize_prompt(vocab, params_p->prompt, add_bos);
@@ -382,7 +384,7 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
             
             // Get token string and callback
             std::string token_str = token_to_piece(vocab, id);
-            if (!tokenCallback(state_pr, (char*)token_str.c_str())) {
+            if (!tokenCallback(state_pr, &token_str[0])) {
                 break;
             }
             
@@ -621,7 +623,16 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
                  bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch, 
                  const char *maingpu, const char *tensorsplit, bool numa, float rope_freq_base, 
                  float rope_freq_scale, const char *lora, const char *lora_base) {
-    
+
+    // These parameters are retained for C ABI stability with the Go layer but
+    // are no longer consumed by llama.cpp: the seed is applied when the sampler
+    // chain is built, KV-cache precision is chosen via the context params, and
+    // low_vram / lora_base were removed from the upstream API.
+    (void) n_seed;
+    (void) memory_f16;
+    (void) low_vram;
+    (void) lora_base;
+
     fprintf(stderr, "%s: loading model from '%s'\n", __func__, fname);
     
     // Initialize backend
@@ -634,8 +645,13 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
     // Setup model parameters
     llama_model_params model_params = llama_model_default_params();
     model_params.n_gpu_layers = n_gpu_layers;
-    model_params.use_mmap = mmap;
-    model_params.use_mlock = mlock;
+    // llama.cpp replaced the use_mmap/use_mlock booleans with a single
+    // load_mode enum. Preserve the binding's semantics: mlock implies mmap
+    // (LLAMA_LOAD_MODE_MLOCK == "mmap + keep resident"), a plain mmap request
+    // maps to LLAMA_LOAD_MODE_MMAP, and neither maps to LLAMA_LOAD_MODE_NONE.
+    model_params.load_mode = mlock ? LLAMA_LOAD_MODE_MLOCK
+                           : mmap  ? LLAMA_LOAD_MODE_MMAP
+                                   : LLAMA_LOAD_MODE_NONE;
     
     // Parse main GPU
     if (maingpu != nullptr && maingpu[0] != '\0') {

--- a/binding.h
+++ b/binding.h
@@ -66,6 +66,20 @@ long long get_model_n_params(void* state_ptr);
 int get_model_description(void* state_ptr, char* buf, int buf_size);
 int get_model_chat_template(void* state_ptr, const char* name, char* buf, int buf_size);
 
+// Extended model geometry
+int get_model_n_head(void* state_ptr);
+int get_model_n_head_kv(void* state_ptr);
+int get_model_n_swa(void* state_ptr);
+float get_model_rope_freq_scale_train(void* state_ptr);
+
+// Model metadata (GGUF key-value header). The *_str functions follow snprintf
+// semantics: they return the length that would be written (>= buf_size means
+// the value was truncated), or -1 if the key/index is absent.
+int get_model_meta_count(void* state_ptr);
+int get_model_meta_val_str(void* state_ptr, const char* key, char* buf, int buf_size);
+int get_model_meta_key_by_index(void* state_ptr, int i, char* buf, int buf_size);
+int get_model_meta_val_str_by_index(void* state_ptr, int i, char* buf, int buf_size);
+
 // Chat template application
 int apply_chat_template(void* state_ptr, const char* tmpl, const char* messages_json,
                         bool add_generation_prompt, char* result, int result_size);
@@ -79,6 +93,17 @@ int get_vocab_sep(void* state_ptr);
 bool get_vocab_add_bos(void* state_ptr);
 bool get_vocab_add_eos(void* state_ptr);
 
+// Extended special tokens (padding, mask, and fill-in-the-middle). Return -1
+// (LLAMA_TOKEN_NULL) when the model's vocabulary does not define the token.
+int get_vocab_pad(void* state_ptr);
+int get_vocab_mask(void* state_ptr);
+int get_vocab_fim_pre(void* state_ptr);
+int get_vocab_fim_suf(void* state_ptr);
+int get_vocab_fim_mid(void* state_ptr);
+int get_vocab_fim_pad(void* state_ptr);
+int get_vocab_fim_rep(void* state_ptr);
+int get_vocab_fim_sep(void* state_ptr);
+
 // Model architecture queries
 bool model_has_encoder(void* state_ptr);
 bool model_has_decoder(void* state_ptr);
@@ -86,6 +111,15 @@ bool model_is_recurrent(void* state_ptr);
 
 // System info
 int get_system_info(char* buf, int buf_size);
+
+// Backend capability queries. These reflect how the llama.cpp library was
+// compiled and require no loaded model.
+bool backend_supports_mmap(void);
+bool backend_supports_mlock(void);
+bool backend_supports_gpu_offload(void);
+bool backend_supports_rpc(void);
+int backend_max_devices(void);
+int backend_max_parallel_sequences(void);
 
 #ifdef __cplusplus
 }

--- a/llama.go
+++ b/llama.go
@@ -64,13 +64,17 @@ func (l *LLama) Free() {
 
 // ModelInfo contains information about the loaded model
 type ModelInfo struct {
-	VocabSize     int
-	ContextLength int
-	EmbeddingSize int
-	LayerCount    int
-	ModelSize     int64
-	ParamCount    int64
-	Description   string
+	VocabSize          int
+	ContextLength      int
+	EmbeddingSize      int
+	LayerCount         int
+	HeadCount          int
+	HeadCountKV        int
+	SlidingWindow      int // n_swa; 0 when the model does not use sliding-window attention
+	RopeFreqScaleTrain float32
+	ModelSize          int64
+	ParamCount         int64
+	Description        string
 }
 
 // GetModelInfo returns information about the loaded model
@@ -79,14 +83,73 @@ func (l *LLama) GetModelInfo() ModelInfo {
 	C.get_model_description(l.state, (*C.char)(unsafe.Pointer(&descBuf[0])), C.int(len(descBuf)))
 
 	return ModelInfo{
-		VocabSize:     int(C.get_model_n_vocab(l.state)),
-		ContextLength: int(C.get_model_n_ctx_train(l.state)),
-		EmbeddingSize: int(C.get_model_n_embd(l.state)),
-		LayerCount:    int(C.get_model_n_layer(l.state)),
-		ModelSize:     int64(C.get_model_size(l.state)),
-		ParamCount:    int64(C.get_model_n_params(l.state)),
-		Description:   string(descBuf[:cStrLen(descBuf)]),
+		VocabSize:          int(C.get_model_n_vocab(l.state)),
+		ContextLength:      int(C.get_model_n_ctx_train(l.state)),
+		EmbeddingSize:      int(C.get_model_n_embd(l.state)),
+		LayerCount:         int(C.get_model_n_layer(l.state)),
+		HeadCount:          int(C.get_model_n_head(l.state)),
+		HeadCountKV:        int(C.get_model_n_head_kv(l.state)),
+		SlidingWindow:      int(C.get_model_n_swa(l.state)),
+		RopeFreqScaleTrain: float32(C.get_model_rope_freq_scale_train(l.state)),
+		ModelSize:          int64(C.get_model_size(l.state)),
+		ParamCount:         int64(C.get_model_n_params(l.state)),
+		Description:        string(descBuf[:cStrLen(descBuf)]),
 	}
+}
+
+// ModelMetadata returns every key-value entry stored in the GGUF model header
+// (architecture, tokenizer settings, quantization, and so on).
+func (l *LLama) ModelMetadata() map[string]string {
+	n := int(C.get_model_meta_count(l.state))
+	meta := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		key, ok := grow(func(buf []byte) int {
+			return int(C.get_model_meta_key_by_index(l.state, C.int(i),
+				(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+		})
+		if !ok {
+			continue
+		}
+		val, ok := grow(func(buf []byte) int {
+			return int(C.get_model_meta_val_str_by_index(l.state, C.int(i),
+				(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+		})
+		if !ok {
+			continue
+		}
+		meta[key] = val
+	}
+	return meta
+}
+
+// ModelMetadataValue returns the metadata value for a single key. The boolean
+// is false when the key is not present in the model header.
+func (l *LLama) ModelMetadataValue(key string) (string, bool) {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+	return grow(func(buf []byte) int {
+		return int(C.get_model_meta_val_str(l.state, cKey,
+			(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+	})
+}
+
+// grow calls fn with an increasingly large buffer until the written value fits.
+// It follows the snprintf contract used by the llama.cpp string accessors: fn
+// returns the length that would be written (a value >= len(buf) means the
+// output was truncated), or a negative value when the entry is absent.
+func grow(fn func(buf []byte) int) (string, bool) {
+	buf := make([]byte, 512)
+	n := fn(buf)
+	if n < 0 {
+		return "", false
+	}
+	if n >= len(buf) {
+		buf = make([]byte, n+1)
+		if n = fn(buf); n < 0 {
+			return "", false
+		}
+	}
+	return string(buf[:n]), true
 }
 
 // GetChatTemplate returns the chat template for the model
@@ -115,23 +178,40 @@ func cStrLen(b []byte) int {
 	return len(b)
 }
 
-// SpecialTokens contains the special token IDs for the model's vocabulary
+// SpecialTokens contains the special token IDs for the model's vocabulary.
+// A field is -1 (LLAMA_TOKEN_NULL) when the vocabulary does not define it.
 type SpecialTokens struct {
-	BOS int32 // Beginning of sentence
-	EOS int32 // End of sentence
-	EOT int32 // End of turn
-	NL  int32 // Newline
-	SEP int32 // Separator
+	BOS    int32 // Beginning of sentence
+	EOS    int32 // End of sentence
+	EOT    int32 // End of turn
+	NL     int32 // Newline
+	SEP    int32 // Separator
+	PAD    int32 // Padding
+	MASK   int32 // Mask
+	FIMPre int32 // Fill-in-the-middle prefix
+	FIMSuf int32 // Fill-in-the-middle suffix
+	FIMMid int32 // Fill-in-the-middle middle
+	FIMPad int32 // Fill-in-the-middle padding
+	FIMRep int32 // Fill-in-the-middle repository separator
+	FIMSep int32 // Fill-in-the-middle separator
 }
 
 // GetSpecialTokens returns the special token IDs for the model
 func (l *LLama) GetSpecialTokens() SpecialTokens {
 	return SpecialTokens{
-		BOS: int32(C.get_vocab_bos(l.state)),
-		EOS: int32(C.get_vocab_eos(l.state)),
-		EOT: int32(C.get_vocab_eot(l.state)),
-		NL:  int32(C.get_vocab_nl(l.state)),
-		SEP: int32(C.get_vocab_sep(l.state)),
+		BOS:    int32(C.get_vocab_bos(l.state)),
+		EOS:    int32(C.get_vocab_eos(l.state)),
+		EOT:    int32(C.get_vocab_eot(l.state)),
+		NL:     int32(C.get_vocab_nl(l.state)),
+		SEP:    int32(C.get_vocab_sep(l.state)),
+		PAD:    int32(C.get_vocab_pad(l.state)),
+		MASK:   int32(C.get_vocab_mask(l.state)),
+		FIMPre: int32(C.get_vocab_fim_pre(l.state)),
+		FIMSuf: int32(C.get_vocab_fim_suf(l.state)),
+		FIMMid: int32(C.get_vocab_fim_mid(l.state)),
+		FIMPad: int32(C.get_vocab_fim_pad(l.state)),
+		FIMRep: int32(C.get_vocab_fim_rep(l.state)),
+		FIMSep: int32(C.get_vocab_fim_sep(l.state)),
 	}
 }
 
@@ -144,6 +224,28 @@ func (l *LLama) GetVocabAddBOS() bool {
 func (l *LLama) GetVocabAddEOS() bool {
 	return bool(C.get_vocab_add_eos(l.state))
 }
+
+// Backend capability queries. They reflect how the underlying llama.cpp library
+// was compiled and can be called without a loaded model.
+
+// SupportsMmap reports whether memory-mapped model loading is available.
+func SupportsMmap() bool { return bool(C.backend_supports_mmap()) }
+
+// SupportsMlock reports whether locking the model into RAM is available.
+func SupportsMlock() bool { return bool(C.backend_supports_mlock()) }
+
+// SupportsGPUOffload reports whether offloading layers to a GPU is available.
+func SupportsGPUOffload() bool { return bool(C.backend_supports_gpu_offload()) }
+
+// SupportsRPC reports whether the RPC backend is available.
+func SupportsRPC() bool { return bool(C.backend_supports_rpc()) }
+
+// MaxDevices returns the maximum number of devices the backend can address.
+func MaxDevices() int { return int(C.backend_max_devices()) }
+
+// MaxParallelSequences returns the maximum number of sequences that can be
+// decoded in parallel.
+func MaxParallelSequences() int { return int(C.backend_max_parallel_sequences()) }
 
 // ModelHasEncoder returns whether the model has an encoder component
 func (l *LLama) ModelHasEncoder() bool {

--- a/llama_test.go
+++ b/llama_test.go
@@ -132,12 +132,60 @@ how much is 2+2?
 			Expect(info.ParamCount).To(BeNumerically(">", 0))
 			Expect(info.Description).ToNot(BeEmpty())
 		})
+
+		It("exposes extended model geometry", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, _ := getModel()
+			info := model.GetModelInfo()
+			Expect(info.HeadCount).To(BeNumerically(">", 0))
+			Expect(info.HeadCountKV).To(BeNumerically(">", 0))
+			// Attention heads are shared (MHA/GQA/MQA): KV heads never exceed query heads.
+			Expect(info.HeadCountKV).To(BeNumerically("<=", info.HeadCount))
+			Expect(info.RopeFreqScaleTrain).To(BeNumerically(">", 0))
+			Expect(info.SlidingWindow).To(BeNumerically(">=", 0))
+		})
+
+		It("exposes model metadata", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, _ := getModel()
+			meta := model.ModelMetadata()
+			Expect(meta).ToNot(BeEmpty())
+			Expect(meta).To(HaveKey("general.architecture"))
+
+			arch, ok := model.ModelMetadataValue("general.architecture")
+			Expect(ok).To(BeTrue())
+			Expect(arch).ToNot(BeEmpty())
+			Expect(arch).To(Equal(meta["general.architecture"]))
+
+			_, ok = model.ModelMetadataValue("this.key.does.not.exist")
+			Expect(ok).To(BeFalse())
+		})
 	})
 
 	Context("System info", func() {
 		It("returns system info string", func() {
 			info := llama.SystemInfo()
 			Expect(info).ToNot(BeEmpty())
+		})
+	})
+
+	Context("Backend capabilities", func() {
+		It("reports capability flags without a loaded model", func() {
+			// These reflect compiled-in backend features and must not require a model.
+			Expect(llama.MaxParallelSequences()).To(BeNumerically(">=", 1))
+			Expect(llama.MaxDevices()).To(BeNumerically(">=", 0))
+			// mmap is available on every platform in the CI matrix.
+			Expect(llama.SupportsMmap()).To(BeTrue())
+			// The remaining queries must at least execute without panicking.
+			_ = llama.SupportsMlock()
+			_ = llama.SupportsGPUOffload()
+			_ = llama.SupportsRPC()
 		})
 	})
 


### PR DESCRIPTION
Part of the engine-coverage series. **Stacked on #178** (base is the `8f5ab83` fix branch); GitHub will retarget this to `main` once #178 merges.

Adds read-only accessors that were missing from the binding, broadening coverage of the llama.cpp public API:

- **Extended model geometry** on `ModelInfo`: `HeadCount`, `HeadCountKV`, `SlidingWindow` (n_swa), `RopeFreqScaleTrain`
- **GGUF metadata**: `ModelMetadata()` dumps every key-value entry; `ModelMetadataValue(key)` looks one up (both with snprintf-style buffer growth)
- **Extended special tokens** on `SpecialTokens`: `PAD`, `MASK`, and the fill-in-the-middle tokens (`FIMPre/Suf/Mid/Pad/Rep/Sep`)
- **Backend capability queries** (no model required): `SupportsMmap`, `SupportsMlock`, `SupportsGPUOffload`, `SupportsRPC`, `MaxDevices`, `MaxParallelSequences`

Also fixes the README "Model Information API" example, which referenced `ModelInfo` fields that don't exist (`NVocab`, `NCtxTrain`, …) and wouldn't compile.

All additive and ABI-safe. Adds Ginkgo tests, including a model-free backend-capability check that runs without `TEST_MODEL`. `binding.cpp` compiles clean under `-Wall -Wextra -Wpedantic -Wcast-qual` against `8f5ab83`.