### PR TITLE
fix: apply the parsed logit_bias in the sampler chain

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -230,7 +230,18 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
     
     // Initialize sampler chain
     llama_sampler * smpl = llama_sampler_chain_init(llama_sampler_chain_default_params());
-    
+
+    // Apply logit bias first so it influences every downstream sampler,
+    // including greedy selection. params_p->logit_bias is populated only when
+    // the caller passes a "token(+|-)value" bias string; previously it was
+    // parsed but never wired into the chain, so the bias was silently ignored.
+    if (!params_p->logit_bias.empty()) {
+        llama_sampler_chain_add(smpl, llama_sampler_init_logit_bias(
+            llama_vocab_n_tokens(vocab),
+            (int32_t) params_p->logit_bias.size(),
+            params_p->logit_bias.data()));
+    }
+
     // Add samplers based on parameters
     if (params_p->temp <= 0) {
         // Greedy sampling

--- a/binding.cpp
+++ b/binding.cpp
@@ -24,8 +24,12 @@
 #include <signal.h>
 #include <unistd.h>
 #elif defined (_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <signal.h>
 #endif
@@ -207,11 +211,9 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
     // state across calls on purpose.
     llama_memory_seq_rm(mem, -1, -1, -1);
 
-    // Set seed if specified
-    if (params_p->seed != LLAMA_DEFAULT_SEED) {
-        // Seed is now set during sampler initialization
-    }
-    
+    // Note: the RNG seed is applied when the sampler chain is built below
+    // (llama_sampler_init_dist / mirostat), not on the context.
+
     // Tokenize prompt
     bool add_bos = llama_vocab_get_add_bos(vocab);
     std::vector<llama_token> embd_inp = tokenize_prompt(vocab, params_p->prompt, add_bos);
@@ -382,7 +384,7 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
             
             // Get token string and callback
             std::string token_str = token_to_piece(vocab, id);
-            if (!tokenCallback(state_pr, (char*)token_str.c_str())) {
+            if (!tokenCallback(state_pr, &token_str[0])) {
                 break;
             }
             
@@ -621,7 +623,16 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
                  bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch, 
                  const char *maingpu, const char *tensorsplit, bool numa, float rope_freq_base, 
                  float rope_freq_scale, const char *lora, const char *lora_base) {
-    
+
+    // These parameters are retained for C ABI stability with the Go layer but
+    // are no longer consumed by llama.cpp: the seed is applied when the sampler
+    // chain is built, KV-cache precision is chosen via the context params, and
+    // low_vram / lora_base were removed from the upstream API.
+    (void) n_seed;
+    (void) memory_f16;
+    (void) low_vram;
+    (void) lora_base;
+
     fprintf(stderr, "%s: loading model from '%s'\n", __func__, fname);
     
     // Initialize backend
@@ -634,8 +645,13 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
     // Setup model parameters
     llama_model_params model_params = llama_model_default_params();
     model_params.n_gpu_layers = n_gpu_layers;
-    model_params.use_mmap = mmap;
-    model_params.use_mlock = mlock;
+    // llama.cpp replaced the use_mmap/use_mlock booleans with a single
+    // load_mode enum. Preserve the binding's semantics: mlock implies mmap
+    // (LLAMA_LOAD_MODE_MLOCK == "mmap + keep resident"), a plain mmap request
+    // maps to LLAMA_LOAD_MODE_MMAP, and neither maps to LLAMA_LOAD_MODE_NONE.
+    model_params.load_mode = mlock ? LLAMA_LOAD_MODE_MLOCK
+                           : mmap  ? LLAMA_LOAD_MODE_MMAP
+                                   : LLAMA_LOAD_MODE_NONE;
     
     // Parse main GPU
     if (maingpu != nullptr && maingpu[0] != '\0') {

--- a/llama_test.go
+++ b/llama_test.go
@@ -67,6 +67,24 @@ how much is 2+2?
 			Expect(text).To(ContainSubstring("4"), text)
 		})
 
+		It("applies logit bias during generation", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, err := getModel()
+			Expect(err).ToNot(HaveOccurred())
+
+			// A bias string is "token(+|-)value". This exercises the logit-bias
+			// path, which was previously parsed but never added to the sampler
+			// chain; generation must still succeed and produce output.
+			text, err := model.Predict(`[INST] Answer to the following question:
+how much is 2+2?
+[/INST]`, llama.SetLogitBias("5+1.0"))
+			Expect(err).ToNot(HaveOccurred(), text)
+			Expect(text).ToNot(BeEmpty())
+		})
+
 		It("tokenizes strings successfully", func() {
 			if testModelPath == "" {
 				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")


### PR DESCRIPTION
Independent bug fix, based on the #178 fix branch (retargets to `main` when #178 merges).

**Bug:** `SetLogitBias(...)` has no effect. `llama_allocate_params` parses the `"token(+|-)value"` string into `binding_params::logit_bias`, but `llama_predict` never adds a `llama_sampler_init_logit_bias` stage to the sampler chain — so the parsed bias is silently dropped.

**Fix:** add the logit-bias sampler right after the chain is initialized, so it influences every downstream sampler (including greedy selection). Adds a generation test that exercises the path.

`binding.cpp` compiles clean against `8f5ab83`.