### PR TITLE
feat: multi-LoRA adapter management (ApplyLoRA / ClearLoRA)

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -38,6 +38,10 @@
 struct llama_binding_state {
     llama_model * model;
     llama_context * ctx;
+    // Active LoRA adapters applied to the context, kept so the whole set can be
+    // re-applied (llama_set_adapters_lora replaces the set) and freed on teardown.
+    std::vector<llama_adapter_lora *> lora_adapters;
+    std::vector<float> lora_scales;
 };
 
 // Parameters structure to pass sampling/generation config
@@ -453,10 +457,46 @@ void llama_binding_free_model(void *state_ptr) {
     if (state->ctx != nullptr) {
         llama_free(state->ctx);
     }
+    // Free adapters added via apply_lora_adapter while the model is still alive
+    // (llama_adapter_lora_free detaches each from the model's set), then free
+    // the model itself, which releases any remaining untracked adapters.
+    for (llama_adapter_lora * adapter : state->lora_adapters) {
+        llama_adapter_lora_free(adapter);
+    }
+    state->lora_adapters.clear();
+    state->lora_scales.clear();
     if (state->model != nullptr) {
         llama_model_free(state->model);
     }
     delete state;
+}
+
+// Load a LoRA adapter from file and add it to the set active on the context.
+// llama_set_adapters_lora replaces the whole set, so the binding tracks every
+// applied adapter and re-applies them together. Returns 0 on success, non-zero
+// if the adapter could not be loaded or applied.
+int apply_lora_adapter(void* state_ptr, const char* path, float scale) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_adapter_lora * adapter = llama_adapter_lora_init(state->model, path);
+    if (adapter == nullptr) {
+        return 1;
+    }
+    state->lora_adapters.push_back(adapter);
+    state->lora_scales.push_back(scale);
+    return llama_set_adapters_lora(state->ctx, state->lora_adapters.data(),
+                                   state->lora_adapters.size(), state->lora_scales.data());
+}
+
+// Detach and free every LoRA adapter previously applied via apply_lora_adapter.
+int clear_lora_adapters(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    int ret = llama_set_adapters_lora(state->ctx, nullptr, 0, nullptr);
+    for (llama_adapter_lora * adapter : state->lora_adapters) {
+        llama_adapter_lora_free(adapter);
+    }
+    state->lora_adapters.clear();
+    state->lora_scales.clear();
+    return ret;
 }
 
 void llama_free_params(void* params_ptr) {

--- a/binding.h
+++ b/binding.h
@@ -52,6 +52,12 @@ void llama_free_params(void* params_ptr);
 
 void llama_binding_free_model(void* state);
 
+// LoRA adapters. apply_lora_adapter loads an adapter and adds it to the set
+// active on the context (returns 0 on success). clear_lora_adapters detaches
+// and frees every adapter previously applied this way.
+int apply_lora_adapter(void* state_ptr, const char* path, float scale);
+int clear_lora_adapters(void* state_ptr);
+
 int llama_tokenize_string(void* params_ptr, void* state_pr, int* result);
 
 // Direct tokenization helpers that do not require a binding_params struct.

--- a/llama.go
+++ b/llama.go
@@ -62,6 +62,24 @@ func (l *LLama) Free() {
 	C.llama_binding_free_model(l.state)
 }
 
+// ApplyLoRA loads a LoRA adapter from path and applies it to the context with
+// the given scale. Adapters stack: each call adds to the active set. Adapters
+// applied this way are released by ClearLoRA or when the model is freed.
+func (l *LLama) ApplyLoRA(path string, scale float32) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	if C.apply_lora_adapter(l.state, cPath, C.float(scale)) != 0 {
+		return fmt.Errorf("failed to apply LoRA adapter %q", path)
+	}
+	return nil
+}
+
+// ClearLoRA detaches and frees every LoRA adapter previously applied with
+// ApplyLoRA, returning the context to the base model weights.
+func (l *LLama) ClearLoRA() {
+	C.clear_lora_adapters(l.state)
+}
+
 // ModelInfo contains information about the loaded model
 type ModelInfo struct {
 	VocabSize          int

--- a/llama_test.go
+++ b/llama_test.go
@@ -206,6 +206,21 @@ how much is 2+2?
 			_, ok = model.ModelMetadataValue("this.key.does.not.exist")
 			Expect(ok).To(BeFalse())
 		})
+
+		It("reports an error for a missing LoRA adapter", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, _ := getModel()
+			// Applying a nonexistent adapter must fail cleanly: the loader
+			// returns null rather than throwing across the C boundary.
+			err := model.ApplyLoRA("does-not-exist.gguf", 1.0)
+			Expect(err).To(HaveOccurred())
+
+			// Clearing when nothing is applied must be a safe no-op.
+			model.ClearLoRA()
+		})
 	})
 
 	Context("System info", func() {


### PR DESCRIPTION
Part of the engine-coverage series. Based on the #178 fix branch (retargets to `main` when #178 merges); independent of the other feature PRs.

Adds runtime LoRA adapter management on the context:

- `ApplyLoRA(path string, scale float32) error` — load an adapter and add it to the active set (adapters stack)
- `ClearLoRA()` — detach and free every adapter applied that way

**Design.** `llama_set_adapters_lora` replaces the entire adapter set, so the binding state tracks the applied adapters + scales and re-applies them together. Lifetime is verified against the engine source:

- teardown order is context → adapters (while the model is still alive) → model, avoiding use-after-free;
- `llama_adapter_lora_free` erases each adapter from the model's set, so there is no double free with the model's own cleanup;
- `llama_adapter_lora_init` catches exceptions and returns null, so a bad path can't throw across the C ABI.

**Testing.** Adds an error-path test (missing adapter fails cleanly; `ClearLoRA` on an empty set is a safe no-op). The happy path needs an actual adapter file, which CI doesn't carry, so it's validated by construction + the verified lifetime semantics; a `TEST_MODEL` + adapter file run would exercise it end to end.

`binding.cpp` compiles clean under `-Wall -Wextra -Wpedantic -Wcast-qual` against `8f5ab83`.