### PR TITLE
feat: low-level batching, decode/encode, and KV-cache control

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -44,6 +44,14 @@ struct llama_binding_state {
     std::vector<float> lora_scales;
 };
 
+// Wrapper around a llama_batch that also remembers its capacity, so batch_add
+// can bounds-check (llama_batch itself only stores the current token count).
+struct binding_batch {
+    llama_batch batch;
+    int32_t capacity;
+    int32_t n_seq_max;
+};
+
 // Parameters structure to pass sampling/generation config
 struct binding_params {
     std::string prompt;
@@ -197,6 +205,142 @@ int get_token_embeddings(void* params_ptr, void* state_pr, int *tokens, int toke
     params_p->prompt = prompt;
     
     return get_embeddings(params_ptr, state_pr, res_embeddings);
+}
+
+// ---------------------------------------------------------------------------
+// Low-level batching, decoding, and output access
+// ---------------------------------------------------------------------------
+
+void* batch_init(int n_tokens, int n_seq_max) {
+    binding_batch* w = new binding_batch;
+    w->batch = llama_batch_init(n_tokens, 0, n_seq_max);
+    w->capacity = n_tokens;
+    w->n_seq_max = n_seq_max;
+    return w;
+}
+
+void batch_free(void* batch_ptr) {
+    binding_batch* w = (binding_batch*) batch_ptr;
+    llama_batch_free(w->batch);
+    delete w;
+}
+
+void batch_clear(void* batch_ptr) {
+    ((binding_batch*) batch_ptr)->batch.n_tokens = 0;
+}
+
+int batch_n_tokens(void* batch_ptr) {
+    return ((binding_batch*) batch_ptr)->batch.n_tokens;
+}
+
+// Append one token at position pos for the given sequence ids, flagging whether
+// its output (logits/embeddings) is wanted. Returns the slot index, -1 if the
+// batch is full, or -2 if n_seq_ids exceeds the batch's configured n_seq_max.
+int batch_add(void* batch_ptr, int token, int pos, const int* seq_ids, int n_seq_ids, bool logits) {
+    binding_batch* w = (binding_batch*) batch_ptr;
+    llama_batch & b = w->batch;
+    if (b.n_tokens >= w->capacity) {
+        return -1;
+    }
+    if (n_seq_ids > w->n_seq_max) {
+        return -2;
+    }
+    const int idx = b.n_tokens;
+    b.token[idx]    = token;
+    b.pos[idx]      = pos;
+    b.n_seq_id[idx] = n_seq_ids;
+    for (int k = 0; k < n_seq_ids; k++) {
+        b.seq_id[idx][k] = seq_ids[k];
+    }
+    b.logits[idx] = logits ? 1 : 0;
+    b.n_tokens++;
+    return idx;
+}
+
+// Decode a batch using the KV cache. Returns llama_decode's status: 0 success,
+// 1 = no KV slot, 2 = aborted, negative = error.
+int decode_batch(void* state_ptr, void* batch_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_decode(state->ctx, ((binding_batch*) batch_ptr)->batch);
+}
+
+// Encode a batch (encoder-decoder models). Returns 0 on success, negative on error.
+int encode_batch(void* state_ptr, void* batch_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_encode(state->ctx, ((binding_batch*) batch_ptr)->batch);
+}
+
+// Copy up to out_size logits for the i-th output token (-1 = last) into out.
+// Returns the number copied, or 0 if unavailable.
+int get_logits_ith(void* state_ptr, int i, float* out, int out_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const float* logits = llama_get_logits_ith(state->ctx, i);
+    if (logits == nullptr) {
+        return 0;
+    }
+    int n = llama_vocab_n_tokens(llama_model_get_vocab(state->model));
+    if (n > out_size) {
+        n = out_size;
+    }
+    for (int k = 0; k < n; k++) {
+        out[k] = logits[k];
+    }
+    return n;
+}
+
+// Copy up to out_size embeddings for the i-th output token (-1 = last) into out.
+int get_embeddings_ith(void* state_ptr, int i, float* out, int out_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const float* emb = llama_get_embeddings_ith(state->ctx, i);
+    if (emb == nullptr) {
+        return 0;
+    }
+    int n = llama_model_n_embd(state->model);
+    if (n > out_size) {
+        n = out_size;
+    }
+    for (int k = 0; k < n; k++) {
+        out[k] = emb[k];
+    }
+    return n;
+}
+
+// Copy up to out_size pooled embeddings for an entire sequence into out.
+int get_embeddings_seq(void* state_ptr, int seq_id, float* out, int out_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const float* emb = llama_get_embeddings_seq(state->ctx, seq_id);
+    if (emb == nullptr) {
+        return 0;
+    }
+    int n = llama_model_n_embd(state->model);
+    if (n > out_size) {
+        n = out_size;
+    }
+    for (int k = 0; k < n; k++) {
+        out[k] = emb[k];
+    }
+    return n;
+}
+
+// KV-cache / sequence management on the context memory.
+void memory_clear(void* state_ptr, bool data) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_memory_clear(llama_get_memory(state->ctx), data);
+}
+
+bool memory_seq_rm(void* state_ptr, int seq_id, int p0, int p1) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_memory_seq_rm(llama_get_memory(state->ctx), seq_id, p0, p1);
+}
+
+void memory_seq_cp(void* state_ptr, int src, int dst, int p0, int p1) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_memory_seq_cp(llama_get_memory(state->ctx), src, dst, p0, p1);
+}
+
+void memory_seq_keep(void* state_ptr, int seq_id) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_memory_seq_keep(llama_get_memory(state->ctx), seq_id);
 }
 
 int llama_predict(void* params_ptr, void* state_pr, char* result, int result_size, bool debug) {

--- a/binding.h
+++ b/binding.h
@@ -75,6 +75,25 @@ int token_to_piece_str(void* state_ptr, int token, char* buf, int buf_size, bool
 
 int llama_predict(void* params_ptr, void* state_pr, char* result, int result_size, bool debug);
 
+// Low-level batching, decoding, and output access. batch_init allocates an
+// opaque batch (free with batch_free); batch_add appends tokens; decode_batch /
+// encode_batch run it through the model; get_logits_ith / get_embeddings_ith /
+// get_embeddings_seq copy outputs; the memory_* helpers manage the KV cache.
+void* batch_init(int n_tokens, int n_seq_max);
+void batch_free(void* batch_ptr);
+void batch_clear(void* batch_ptr);
+int batch_n_tokens(void* batch_ptr);
+int batch_add(void* batch_ptr, int token, int pos, const int* seq_ids, int n_seq_ids, bool logits);
+int decode_batch(void* state_ptr, void* batch_ptr);
+int encode_batch(void* state_ptr, void* batch_ptr);
+int get_logits_ith(void* state_ptr, int i, float* out, int out_size);
+int get_embeddings_ith(void* state_ptr, int i, float* out, int out_size);
+int get_embeddings_seq(void* state_ptr, int seq_id, float* out, int out_size);
+void memory_clear(void* state_ptr, bool data);
+bool memory_seq_rm(void* state_ptr, int seq_id, int p0, int p1);
+void memory_seq_cp(void* state_ptr, int src, int dst, int p0, int p1);
+void memory_seq_keep(void* state_ptr, int seq_id);
+
 // Model info functions
 int get_model_n_vocab(void* state_ptr);
 int get_model_n_ctx_train(void* state_ptr);

--- a/llama.go
+++ b/llama.go
@@ -80,6 +80,136 @@ func (l *LLama) ClearLoRA() {
 	C.clear_lora_adapters(l.state)
 }
 
+// Batch accumulates tokens — each with a position, sequence IDs, and a flag for
+// whether its output is wanted — for a Decode or Encode call. It wraps the
+// engine's llama_batch; call Free when done.
+type Batch struct {
+	ptr      unsafe.Pointer
+	capacity int
+}
+
+// NewBatch allocates a batch holding up to maxTokens tokens, each assignable to
+// up to maxSeq sequences.
+func NewBatch(maxTokens, maxSeq int) *Batch {
+	return &Batch{
+		ptr:      C.batch_init(C.int(maxTokens), C.int(maxSeq)),
+		capacity: maxTokens,
+	}
+}
+
+// Free releases the batch. It must not be used afterwards.
+func (b *Batch) Free() { C.batch_free(b.ptr) }
+
+// Reset empties the batch so it can be refilled without reallocating.
+func (b *Batch) Reset() { C.batch_clear(b.ptr) }
+
+// Len returns the number of tokens currently in the batch.
+func (b *Batch) Len() int { return int(C.batch_n_tokens(b.ptr)) }
+
+// Add appends token at position pos for the given sequence IDs (defaulting to
+// sequence 0 when none are given). Set logits to request the model's output for
+// this token. It returns an error if the batch is full or too many sequence IDs
+// are supplied.
+func (b *Batch) Add(token int32, pos int32, seqIDs []int32, logits bool) error {
+	if len(seqIDs) == 0 {
+		seqIDs = []int32{0}
+	}
+	ret := int(C.batch_add(b.ptr, C.int(token), C.int(pos),
+		(*C.int)(unsafe.Pointer(&seqIDs[0])), C.int(len(seqIDs)), C.bool(logits)))
+	switch ret {
+	case -1:
+		return fmt.Errorf("batch is full (capacity %d)", b.capacity)
+	case -2:
+		return fmt.Errorf("too many sequence IDs for one token (%d)", len(seqIDs))
+	}
+	return nil
+}
+
+// Decode runs the batch through the model using the KV cache. The return value
+// is llama.cpp's decode status: 0 success, 1 = no KV slot (reduce the batch or
+// grow the context), 2 = aborted, negative = error.
+func (l *LLama) Decode(b *Batch) int {
+	return int(C.decode_batch(l.state, b.ptr))
+}
+
+// Encode runs the batch through the encoder of an encoder-decoder model. It
+// returns 0 on success, negative on error.
+func (l *LLama) Encode(b *Batch) int {
+	return int(C.encode_batch(l.state, b.ptr))
+}
+
+// Logits returns the vocabulary logits for the i-th output token of the last
+// decoded batch; i = -1 selects the last token. It returns nil when no logits
+// are available for that index (the token was added without requesting output).
+func (l *LLama) Logits(i int) []float32 {
+	n := int(C.get_model_n_vocab(l.state))
+	if n <= 0 {
+		return nil
+	}
+	out := make([]float32, n)
+	got := int(C.get_logits_ith(l.state, C.int(i),
+		(*C.float)(unsafe.Pointer(&out[0])), C.int(n)))
+	if got <= 0 {
+		return nil
+	}
+	return out[:got]
+}
+
+// TokenEmbedding returns the embedding vector for the i-th output token of the
+// last decoded batch; i = -1 selects the last token. Returns nil if unavailable.
+func (l *LLama) TokenEmbedding(i int) []float32 {
+	return l.embeddingBuf(func(out []float32) int {
+		return int(C.get_embeddings_ith(l.state, C.int(i),
+			(*C.float)(unsafe.Pointer(&out[0])), C.int(len(out))))
+	})
+}
+
+// SequenceEmbedding returns the pooled embedding for an entire sequence (for a
+// context configured with pooled embeddings). Returns nil if unavailable.
+func (l *LLama) SequenceEmbedding(seqID int32) []float32 {
+	return l.embeddingBuf(func(out []float32) int {
+		return int(C.get_embeddings_seq(l.state, C.int(seqID),
+			(*C.float)(unsafe.Pointer(&out[0])), C.int(len(out))))
+	})
+}
+
+func (l *LLama) embeddingBuf(fn func(out []float32) int) []float32 {
+	n := int(C.get_model_n_embd(l.state))
+	if n <= 0 {
+		return nil
+	}
+	out := make([]float32, n)
+	got := fn(out)
+	if got <= 0 {
+		return nil
+	}
+	return out[:got]
+}
+
+// MemoryClear drops the context's KV cache. When clearData is true the
+// underlying data buffers are cleared too, not just the cell metadata.
+func (l *LLama) MemoryClear(clearData bool) {
+	C.memory_clear(l.state, C.bool(clearData))
+}
+
+// MemorySeqRemove removes tokens in [p0, p1) for sequence seqID from the KV
+// cache. Pass p0 < 0 to start at 0 and p1 < 0 to run to the end; seqID < 0
+// matches every sequence. It reports whether the removal succeeded.
+func (l *LLama) MemorySeqRemove(seqID, p0, p1 int32) bool {
+	return bool(C.memory_seq_rm(l.state, C.int(seqID), C.int(p0), C.int(p1)))
+}
+
+// MemorySeqCopy copies tokens in [p0, p1) from sequence src to dst in the KV
+// cache — the shared-prefix trick for parallel sequences.
+func (l *LLama) MemorySeqCopy(src, dst, p0, p1 int32) {
+	C.memory_seq_cp(l.state, C.int(src), C.int(dst), C.int(p0), C.int(p1))
+}
+
+// MemorySeqKeep removes every sequence from the KV cache except seqID.
+func (l *LLama) MemorySeqKeep(seqID int32) {
+	C.memory_seq_keep(l.state, C.int(seqID))
+}
+
 // ModelInfo contains information about the loaded model
 type ModelInfo struct {
 	VocabSize          int

--- a/llama_test.go
+++ b/llama_test.go
@@ -244,6 +244,54 @@ how much is 2+2?
 		})
 	})
 
+	Context("Low-level batching", func() {
+		It("bounds-checks batch capacity", func() {
+			// Batch allocation and the capacity guard need no model.
+			batch := NewBatch(1, 1)
+			defer batch.Free()
+			Expect(batch.Add(1, 0, []int32{0}, false)).To(Succeed())
+			// The second token exceeds capacity 1 and must be rejected.
+			Expect(batch.Add(2, 1, []int32{0}, false)).To(HaveOccurred())
+			Expect(batch.Len()).To(Equal(1))
+		})
+
+		It("decodes a batch and returns next-token logits", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(model).ToNot(BeNil())
+			model.MemoryClear(true)
+
+			tokens := model.Tokenize("The capital of France is", true, false)
+			Expect(tokens).ToNot(BeEmpty())
+
+			batch := NewBatch(len(tokens), 1)
+			defer batch.Free()
+			for i, tok := range tokens {
+				// Request output only for the final token of the sequence.
+				Expect(batch.Add(tok, int32(i), []int32{0}, i == len(tokens)-1)).To(Succeed())
+			}
+			Expect(batch.Len()).To(Equal(len(tokens)))
+			Expect(model.Decode(batch)).To(Equal(0))
+
+			logits := model.Logits(-1)
+			Expect(logits).To(HaveLen(model.GetModelInfo().VocabSize))
+
+			// A real forward pass yields a well-defined, in-range argmax.
+			best, bestIdx := logits[0], 0
+			for i, v := range logits {
+				if v > best {
+					best, bestIdx = v, i
+				}
+			}
+			Expect(bestIdx).To(BeNumerically(">=", 0))
+			Expect(bestIdx).To(BeNumerically("<", model.GetModelInfo().VocabSize))
+		})
+	})
+
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {
 		getModel := func() (*LLama, error) {
 			model, err := New(


### PR DESCRIPTION
Part of the engine-coverage series (the "go all the way" batching layer). Based on current `main`.

Exposes the engine's batch/decode API so callers can build custom generation loops and drive parallel sequences:

- **`Batch`** — `NewBatch(maxTokens, maxSeq)`, `Add(token, pos, seqIDs, logits)`, `Reset`, `Len`, `Free`. Wraps `llama_batch` with a tracked capacity so `Add` bounds-checks and can never overflow the token arrays.
- **`Decode` / `Encode`** — run a batch through the model. `Decode` uses the KV cache; `Encode` drives the encoder of encoder-decoder models. Return values are llama.cpp's decode status (0 ok, 1 = no KV slot, 2 = aborted, <0 = error).
- **Outputs** — `Logits(i)` (per-token vocabulary logits), `TokenEmbedding(i)`, `SequenceEmbedding(seq)`.
- **KV-cache control** — `MemoryClear`, `MemorySeqRemove`, `MemorySeqCopy`, `MemorySeqKeep` for multi-sequence decoding (shared-prefix trick, etc.).

**Implementation notes.** The batch fields are populated directly (exactly what `common_batch_add` does), so the binding depends only on core `LLAMA_API` symbols — no libcommon linkage assumption. The batch wrapper stores its capacity because `llama_batch` itself only tracks the current token count.

**Testing.** A model-free capacity test (runs without `TEST_MODEL`) plus a decode→logits test that runs against the CI model and checks the forward pass yields a well-defined, in-range argmax. `binding.cpp` compiles clean under `-Wall -Wextra -Wpedantic -Wcast-qual` against `8f5ab83`.

> Note: the multi-sequence decode paths are best validated with a local `TEST_MODEL` run; CI exercises the single-sequence decode→logits path.