### PR TITLE
feat: composable sampler objects

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -1156,6 +1156,62 @@ bool backend_supports_rpc(void)           { return llama_supports_rpc(); }
 int  backend_max_devices(void)            { return (int) llama_max_devices(); }
 int  backend_max_parallel_sequences(void) { return (int) llama_max_parallel_sequences(); }
 
+// ---------------------------------------------------------------------------
+// Composable samplers
+// ---------------------------------------------------------------------------
+
+void* sampler_chain_init(void) {
+    return llama_sampler_chain_init(llama_sampler_chain_default_params());
+}
+
+void sampler_chain_add(void* chain, void* smpl) {
+    llama_sampler_chain_add((llama_sampler*) chain, (llama_sampler*) smpl);
+}
+
+void sampler_free(void* smpl) {
+    llama_sampler_free((llama_sampler*) smpl);
+}
+
+void sampler_reset(void* smpl) {
+    llama_sampler_reset((llama_sampler*) smpl);
+}
+
+void sampler_accept(void* smpl, int token) {
+    llama_sampler_accept((llama_sampler*) smpl, token);
+}
+
+int sampler_sample(void* state_ptr, void* smpl, int idx) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_sampler_sample((llama_sampler*) smpl, state->ctx, idx);
+}
+
+void* sampler_init_greedy(void)                    { return llama_sampler_init_greedy(); }
+void* sampler_init_dist(unsigned int seed)         { return llama_sampler_init_dist(seed); }
+void* sampler_init_top_k(int k)                    { return llama_sampler_init_top_k(k); }
+void* sampler_init_top_p(float p, int min_keep)    { return llama_sampler_init_top_p(p, (size_t) min_keep); }
+void* sampler_init_min_p(float p, int min_keep)    { return llama_sampler_init_min_p(p, (size_t) min_keep); }
+void* sampler_init_typical(float p, int min_keep)  { return llama_sampler_init_typical(p, (size_t) min_keep); }
+void* sampler_init_temp(float t)                   { return llama_sampler_init_temp(t); }
+void* sampler_init_temp_ext(float t, float delta, float exponent) { return llama_sampler_init_temp_ext(t, delta, exponent); }
+void* sampler_init_xtc(float p, float t, int min_keep, unsigned int seed) { return llama_sampler_init_xtc(p, t, (size_t) min_keep, seed); }
+void* sampler_init_top_n_sigma(float n)            { return llama_sampler_init_top_n_sigma(n); }
+void* sampler_init_mirostat_v2(unsigned int seed, float tau, float eta) { return llama_sampler_init_mirostat_v2(seed, tau, eta); }
+void* sampler_init_penalties(int last_n, float repeat, float freq, float present) { return llama_sampler_init_penalties(last_n, repeat, freq, present); }
+
+void* sampler_init_grammar(void* state_ptr, const char* grammar, const char* root) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    return llama_sampler_init_grammar(vocab, grammar, root);
+}
+
+void* sampler_init_dry(void* state_ptr, float multiplier, float base, int allowed_length, int penalty_last_n) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    return llama_sampler_init_dry(vocab, llama_model_n_ctx_train(state->model),
+                                  multiplier, base, allowed_length, penalty_last_n,
+                                  nullptr, 0);
+}
+
 int apply_chat_template(void* state_ptr, const char* tmpl, const char* messages_json,
                         bool add_generation_prompt, char* result, int result_size) {
     // Note: This is a simplified implementation - full implementation would need JSON parsing

--- a/binding.h
+++ b/binding.h
@@ -159,6 +159,31 @@ bool backend_supports_rpc(void);
 int backend_max_devices(void);
 int backend_max_parallel_sequences(void);
 
+// Composable samplers. Build a chain with sampler_chain_init, append stages
+// created by the sampler_init_* helpers with sampler_chain_add (the chain takes
+// ownership), then sampler_sample from a decoded context. sampler_free releases
+// a sampler and, for a chain, every stage added to it.
+void* sampler_chain_init(void);
+void sampler_chain_add(void* chain, void* smpl);
+void sampler_free(void* smpl);
+void sampler_reset(void* smpl);
+void sampler_accept(void* smpl, int token);
+int sampler_sample(void* state_ptr, void* smpl, int idx);
+void* sampler_init_greedy(void);
+void* sampler_init_dist(unsigned int seed);
+void* sampler_init_top_k(int k);
+void* sampler_init_top_p(float p, int min_keep);
+void* sampler_init_min_p(float p, int min_keep);
+void* sampler_init_typical(float p, int min_keep);
+void* sampler_init_temp(float t);
+void* sampler_init_temp_ext(float t, float delta, float exponent);
+void* sampler_init_xtc(float p, float t, int min_keep, unsigned int seed);
+void* sampler_init_top_n_sigma(float n);
+void* sampler_init_mirostat_v2(unsigned int seed, float tau, float eta);
+void* sampler_init_penalties(int last_n, float repeat, float freq, float present);
+void* sampler_init_grammar(void* state_ptr, const char* grammar, const char* root);
+void* sampler_init_dry(void* state_ptr, float multiplier, float base, int allowed_length, int penalty_last_n);
+
 #ifdef __cplusplus
 }
 

--- a/llama.go
+++ b/llama.go
@@ -210,6 +210,88 @@ func (l *LLama) MemorySeqKeep(seqID int32) {
 	C.memory_seq_keep(l.state, C.int(seqID))
 }
 
+// Sampler is a single sampling stage or a chain of stages, wrapping llama.cpp's
+// sampler API. Construct stages (SamplerTopK, SamplerTemp, ...), add them to a
+// chain from NewSamplerChain, then Sample from a decoded context.
+type Sampler struct {
+	ptr unsafe.Pointer
+}
+
+// NewSamplerChain creates an empty sampler chain. The chain takes ownership of
+// every stage added to it and frees them all when the chain's Free is called.
+func NewSamplerChain() *Sampler { return &Sampler{ptr: C.sampler_chain_init()} }
+
+// Add appends a stage to the chain, transferring ownership of the stage to the
+// chain. Do not call Free on a stage after adding it. A nil or empty stage is
+// ignored (e.g. an invalid grammar).
+func (s *Sampler) Add(stage *Sampler) {
+	if stage == nil || stage.ptr == nil {
+		return
+	}
+	C.sampler_chain_add(s.ptr, stage.ptr)
+}
+
+// Free releases the sampler (and, for a chain, every stage added to it).
+func (s *Sampler) Free() { C.sampler_free(s.ptr) }
+
+// Reset clears any internal sampler state (penalty history, grammar position…).
+func (s *Sampler) Reset() { C.sampler_reset(s.ptr) }
+
+// Accept informs stateful stages that token was chosen.
+func (s *Sampler) Accept(token int32) { C.sampler_accept(s.ptr, C.int(token)) }
+
+// Sample selects a token from the logits of the idx-th output of the last
+// Decode/Predict on model (idx = -1 selects the last token).
+func (s *Sampler) Sample(model *LLama, idx int) int32 {
+	return int32(C.sampler_sample(model.state, s.ptr, C.int(idx)))
+}
+
+// Sampler stages. min_keep floors how many candidates a truncation stage keeps.
+func SamplerGreedy() *Sampler          { return &Sampler{ptr: C.sampler_init_greedy()} }
+func SamplerDist(seed uint32) *Sampler { return &Sampler{ptr: C.sampler_init_dist(C.uint(seed))} }
+func SamplerTopK(k int) *Sampler       { return &Sampler{ptr: C.sampler_init_top_k(C.int(k))} }
+func SamplerTopP(p float32, minKeep int) *Sampler {
+	return &Sampler{ptr: C.sampler_init_top_p(C.float(p), C.int(minKeep))}
+}
+func SamplerMinP(p float32, minKeep int) *Sampler {
+	return &Sampler{ptr: C.sampler_init_min_p(C.float(p), C.int(minKeep))}
+}
+func SamplerTypical(p float32, minKeep int) *Sampler {
+	return &Sampler{ptr: C.sampler_init_typical(C.float(p), C.int(minKeep))}
+}
+func SamplerTemp(t float32) *Sampler { return &Sampler{ptr: C.sampler_init_temp(C.float(t))} }
+func SamplerTempExt(t, delta, exponent float32) *Sampler {
+	return &Sampler{ptr: C.sampler_init_temp_ext(C.float(t), C.float(delta), C.float(exponent))}
+}
+func SamplerXTC(p, t float32, minKeep int, seed uint32) *Sampler {
+	return &Sampler{ptr: C.sampler_init_xtc(C.float(p), C.float(t), C.int(minKeep), C.uint(seed))}
+}
+func SamplerTopNSigma(n float32) *Sampler {
+	return &Sampler{ptr: C.sampler_init_top_n_sigma(C.float(n))}
+}
+func SamplerMirostatV2(seed uint32, tau, eta float32) *Sampler {
+	return &Sampler{ptr: C.sampler_init_mirostat_v2(C.uint(seed), C.float(tau), C.float(eta))}
+}
+func SamplerPenalties(lastN int, repeat, freq, present float32) *Sampler {
+	return &Sampler{ptr: C.sampler_init_penalties(C.int(lastN), C.float(repeat), C.float(freq), C.float(present))}
+}
+
+// SamplerGrammar builds a GBNF grammar-constrained stage from the model's vocab.
+// The returned stage is empty (ignored by Add) if the grammar fails to parse.
+func (l *LLama) SamplerGrammar(grammar, root string) *Sampler {
+	cG := C.CString(grammar)
+	defer C.free(unsafe.Pointer(cG))
+	cR := C.CString(root)
+	defer C.free(unsafe.Pointer(cR))
+	return &Sampler{ptr: C.sampler_init_grammar(l.state, cG, cR)}
+}
+
+// SamplerDRY builds a DRY ("Don't Repeat Yourself") stage from the model's vocab.
+func (l *LLama) SamplerDRY(multiplier, base float32, allowedLength, penaltyLastN int) *Sampler {
+	return &Sampler{ptr: C.sampler_init_dry(l.state, C.float(multiplier), C.float(base),
+		C.int(allowedLength), C.int(penaltyLastN))}
+}
+
 // ModelInfo contains information about the loaded model
 type ModelInfo struct {
 	VocabSize          int

--- a/llama_test.go
+++ b/llama_test.go
@@ -292,6 +292,34 @@ how much is 2+2?
 		})
 	})
 
+	Context("Composable samplers", func() {
+		It("builds a chain and samples a valid token", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(model).ToNot(BeNil())
+
+			// Predict once so the context holds real logits to sample from.
+			_, err = model.Predict("The capital of France is")
+			Expect(err).ToNot(HaveOccurred())
+
+			chain := NewSamplerChain()
+			defer chain.Free()
+			chain.Add(SamplerTopK(40))
+			chain.Add(SamplerTopP(0.95, 1))
+			chain.Add(SamplerTemp(0.8))
+			chain.Add(SamplerDist(1234))
+
+			tok := chain.Sample(model, -1)
+			Expect(tok).To(BeNumerically(">=", 0))
+			Expect(tok).To(BeNumerically("<", int32(model.GetModelInfo().VocabSize)))
+			chain.Accept(tok)
+		})
+	})
+
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {
 		getModel := func() (*LLama, error) {
 			model, err := New(


### PR DESCRIPTION
Final piece of the engine-coverage series (the "go all the way" sampler layer). Based on current `main`.

Exposes llama.cpp's sampler chain as configurable Go building blocks, so callers can drive their own generation loops (pairs naturally with the `Decode`/`Logits` API in #183):

- **`Sampler`** wraps a `llama_sampler`. `NewSamplerChain()` builds a chain; `Add(stage)` appends a stage and transfers ownership to the chain; `Sample(model, idx)` / `Accept` / `Reset` / `Free` drive it.
- **Stage constructors:** `SamplerGreedy`, `SamplerDist`, `SamplerTopK`, `SamplerTopP`, `SamplerMinP`, `SamplerTypical`, `SamplerTemp`, `SamplerTempExt` (dynamic temperature), `SamplerXTC`, `SamplerTopNSigma`, `SamplerMirostatV2`, `SamplerPenalties`, plus `SamplerGrammar` and `SamplerDRY` (which read the model vocab).

**Implementation.** Thin wrappers over the very same `llama_sampler_init_*` functions the built-in `Predict` path already uses — no new engine dependencies. Ownership is documented: `Add` transfers a stage to the chain, `Free` on the chain releases every stage.

**Testing.** A test builds a `TopK → TopP → Temp → Dist` chain and samples a valid, in-range token from a context after `Predict`. `binding.cpp` compiles clean under `-Wall -Wextra -Wpedantic -Wcast-qual` against `8f5ab83`.