### PR TITLE
fix: build against llama.cpp v0.3.0 sampler API

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -399,7 +399,6 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
         if (params_p->dry_multiplier > 0.0f) {
             llama_sampler_chain_add(smpl, llama_sampler_init_dry(
                 vocab,
-                llama_model_n_ctx_train(model),
                 params_p->dry_multiplier,
                 params_p->dry_base,
                 params_p->dry_allowed_length,
@@ -411,6 +410,7 @@ int llama_predict(void* params_ptr, void* state_pr, char* result, int result_siz
         // Add penalty sampler if needed
         if (params_p->repeat_penalty != 1.0f || params_p->frequency_penalty != 0.0f || params_p->presence_penalty != 0.0f) {
             llama_sampler_chain_add(smpl, llama_sampler_init_penalties(
+                llama_vocab_n_tokens(vocab),
                 params_p->repeat_last_n,
                 params_p->repeat_penalty,
                 params_p->frequency_penalty,
@@ -1196,7 +1196,11 @@ void* sampler_init_temp_ext(float t, float delta, float exponent) { return llama
 void* sampler_init_xtc(float p, float t, int min_keep, unsigned int seed) { return llama_sampler_init_xtc(p, t, (size_t) min_keep, seed); }
 void* sampler_init_top_n_sigma(float n)            { return llama_sampler_init_top_n_sigma(n); }
 void* sampler_init_mirostat_v2(unsigned int seed, float tau, float eta) { return llama_sampler_init_mirostat_v2(seed, tau, eta); }
-void* sampler_init_penalties(int last_n, float repeat, float freq, float present) { return llama_sampler_init_penalties(last_n, repeat, freq, present); }
+void* sampler_init_penalties(void* state_ptr, int last_n, float repeat, float freq, float present) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    return llama_sampler_init_penalties(llama_vocab_n_tokens(vocab), last_n, repeat, freq, present);
+}
 
 void* sampler_init_grammar(void* state_ptr, const char* grammar, const char* root) {
     llama_binding_state* state = (llama_binding_state*) state_ptr;
@@ -1207,8 +1211,7 @@ void* sampler_init_grammar(void* state_ptr, const char* grammar, const char* roo
 void* sampler_init_dry(void* state_ptr, float multiplier, float base, int allowed_length, int penalty_last_n) {
     llama_binding_state* state = (llama_binding_state*) state_ptr;
     const llama_vocab* vocab = llama_model_get_vocab(state->model);
-    return llama_sampler_init_dry(vocab, llama_model_n_ctx_train(state->model),
-                                  multiplier, base, allowed_length, penalty_last_n,
+    return llama_sampler_init_dry(vocab, multiplier, base, allowed_length, penalty_last_n,
                                   nullptr, 0);
 }
 

--- a/binding.h
+++ b/binding.h
@@ -180,7 +180,7 @@ void* sampler_init_temp_ext(float t, float delta, float exponent);
 void* sampler_init_xtc(float p, float t, int min_keep, unsigned int seed);
 void* sampler_init_top_n_sigma(float n);
 void* sampler_init_mirostat_v2(unsigned int seed, float tau, float eta);
-void* sampler_init_penalties(int last_n, float repeat, float freq, float present);
+void* sampler_init_penalties(void* state_ptr, int last_n, float repeat, float freq, float present);
 void* sampler_init_grammar(void* state_ptr, const char* grammar, const char* root);
 void* sampler_init_dry(void* state_ptr, float multiplier, float base, int allowed_length, int penalty_last_n);
 

--- a/llama.go
+++ b/llama.go
@@ -272,8 +272,14 @@ func SamplerTopNSigma(n float32) *Sampler {
 func SamplerMirostatV2(seed uint32, tau, eta float32) *Sampler {
 	return &Sampler{ptr: C.sampler_init_mirostat_v2(C.uint(seed), C.float(tau), C.float(eta))}
 }
-func SamplerPenalties(lastN int, repeat, freq, present float32) *Sampler {
-	return &Sampler{ptr: C.sampler_init_penalties(C.int(lastN), C.float(repeat), C.float(freq), C.float(present))}
+
+// SamplerPenalties builds a repetition/frequency/presence penalty stage. lastN
+// is how many recent tokens to consider (0 disables the stage); repeat, freq
+// and present are the repetition, frequency and presence penalties, where 1.0,
+// 0.0 and 0.0 respectively mean "disabled". It is a method on LLama because the
+// engine sizes the stage from the model's vocabulary.
+func (l *LLama) SamplerPenalties(lastN int, repeat, freq, present float32) *Sampler {
+	return &Sampler{ptr: C.sampler_init_penalties(l.state, C.int(lastN), C.float(repeat), C.float(freq), C.float(present))}
 }
 
 // SamplerGrammar builds a GBNF grammar-constrained stage from the model's vocab.


### PR DESCRIPTION
Supersedes #205, which is red because llama.cpp v0.3.0 changed two sampler constructor signatures.

## The break

`c1d0e7a` bumps llama.cpp to **v0.3.0** and changes:

| Engine function | Change |
| --- | --- |
| `llama_sampler_init_penalties` | gained a leading `int32_t n_vocab` parameter (4 args -> 5) |
| `llama_sampler_init_dry` | dropped its `int32_t n_ctx_train` parameter (8 args -> 7) |

Both are called twice in `binding.cpp` (once in the `llama_predict` chain, once in the exported `sampler_init_*` wrapper), which is the 4 errors CI reported.

## The fix

`n_vocab` cannot be defaulted — the penalties backend asserts `n_vocab > 0` (`llama-sampler.cpp:3043`) — so the binding passes `llama_vocab_n_tokens(vocab)`, matching what upstream `common/sampling.cpp` does.

That means the exported wrapper needs the vocabulary, so it now takes the binding state:

```c
void* sampler_init_penalties(void* state_ptr, int last_n, float repeat, float freq, float present);
```

## Breaking Go API change

```go
llama.SamplerPenalties(lastN, repeat, freq, present)   // before
model.SamplerPenalties(lastN, repeat, freq, present)   // after
```

This is forced by the engine. It also makes the sampler surface consistent: `SamplerGrammar` and `SamplerDRY` are already methods on `*LLama` for exactly the same reason (they need the vocab).

## Verification

- `binding.cpp` compiles clean against the v0.3.0 headers with the full CI flag set (`-Wall -Wextra -Wpedantic -Wcast-qual`) — this is the exact `binding.o` step that failed.
- `go vet ./...` clean, `gofmt -l` clean.