### PR TITLE
feat: context runtime introspection, KV-cache ops, and perf counters

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -904,6 +904,12 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
     ctx_params.n_batch = n_batch;
     ctx_params.n_ubatch = n_batch;
     ctx_params.embeddings = embeddings;
+
+    // llama_context_default_params sets no_perf = true, which makes the engine
+    // skip its own timing calls and leaves llama_perf_context reporting zeros.
+    // The binding exposes those counters through Perf(), so enable them; the
+    // cost is a couple of clock reads per decode.
+    ctx_params.no_perf = false;
     
     if (rope_freq_base != 0.0f) {
         ctx_params.rope_freq_base = rope_freq_base;
@@ -1227,4 +1233,150 @@ int apply_chat_template(void* state_ptr, const char* tmpl, const char* messages_
     (void)result;
     (void)result_size;
     return -1;
+}
+
+//
+// Context runtime introspection and control
+//
+// The engine may clamp or round the values requested through llama_context_params,
+// so these report what the context actually uses rather than what was asked for.
+//
+
+int context_n_ctx(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_n_ctx(state->ctx);
+}
+
+int context_n_ctx_seq(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_n_ctx_seq(state->ctx);
+}
+
+int context_n_batch(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_n_batch(state->ctx);
+}
+
+int context_n_ubatch(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_n_ubatch(state->ctx);
+}
+
+int context_n_seq_max(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_n_seq_max(state->ctx);
+}
+
+int context_n_rs_seq(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_n_rs_seq(state->ctx);
+}
+
+int context_pooling_type(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_pooling_type(state->ctx);
+}
+
+int context_n_threads(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_n_threads(state->ctx);
+}
+
+int context_n_threads_batch(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_n_threads_batch(state->ctx);
+}
+
+void context_set_n_threads(void* state_ptr, int n_threads, int n_threads_batch) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_set_n_threads(state->ctx, n_threads, n_threads_batch);
+}
+
+void context_set_embeddings(void* state_ptr, bool embeddings) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_set_embeddings(state->ctx, embeddings);
+}
+
+void context_set_causal_attn(void* state_ptr, bool causal_attn) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_set_causal_attn(state->ctx, causal_attn);
+}
+
+void context_synchronize(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_synchronize(state->ctx);
+}
+
+//
+// KV-cache (memory) operations not already exposed
+//
+
+void memory_seq_add(void* state_ptr, int seq_id, int p0, int p1, int delta) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_memory_seq_add(llama_get_memory(state->ctx), seq_id, p0, p1, delta);
+}
+
+void memory_seq_div(void* state_ptr, int seq_id, int p0, int p1, int d) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_memory_seq_div(llama_get_memory(state->ctx), seq_id, p0, p1, d);
+}
+
+int memory_seq_pos_min(void* state_ptr, int seq_id) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_memory_seq_pos_min(llama_get_memory(state->ctx), seq_id);
+}
+
+int memory_seq_pos_max(void* state_ptr, int seq_id) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_memory_seq_pos_max(llama_get_memory(state->ctx), seq_id);
+}
+
+bool memory_can_shift(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_memory_can_shift(llama_get_memory(state->ctx));
+}
+
+//
+// Performance counters
+//
+
+void perf_context(void* state_ptr, double* t_start_ms, double* t_load_ms,
+                  double* t_p_eval_ms, double* t_eval_ms,
+                  int* n_p_eval, int* n_eval, int* n_reused) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_perf_context_data d = llama_perf_context(state->ctx);
+    if (t_start_ms)  *t_start_ms  = d.t_start_ms;
+    if (t_load_ms)   *t_load_ms   = d.t_load_ms;
+    if (t_p_eval_ms) *t_p_eval_ms = d.t_p_eval_ms;
+    if (t_eval_ms)   *t_eval_ms   = d.t_eval_ms;
+    if (n_p_eval)    *n_p_eval    = d.n_p_eval;
+    if (n_eval)      *n_eval      = d.n_eval;
+    if (n_reused)    *n_reused    = d.n_reused;
+}
+
+void perf_context_reset(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_perf_context_reset(state->ctx);
+}
+
+void perf_sampler(void* smpl, double* t_sample_ms, int* n_sample) {
+    const llama_perf_sampler_data d = llama_perf_sampler((const llama_sampler*) smpl);
+    if (t_sample_ms) *t_sample_ms = d.t_sample_ms;
+    if (n_sample)    *n_sample    = d.n_sample;
+}
+
+void perf_sampler_reset(void* smpl) {
+    llama_perf_sampler_reset((llama_sampler*) smpl);
+}
+
+//
+// Library-level information
+//
+
+const char* llama_version_str(void) {
+    return llama_version();
+}
+
+long long llama_time_us_val(void) {
+    return (long long) llama_time_us();
 }

--- a/binding.h
+++ b/binding.h
@@ -159,6 +159,46 @@ bool backend_supports_rpc(void);
 int backend_max_devices(void);
 int backend_max_parallel_sequences(void);
 
+
+// Context runtime introspection and control. The engine may clamp or round the
+// values requested via load_model, so these report what the context actually
+// uses. context_pooling_type returns a llama_pooling_type enum value.
+int context_n_ctx(void* state_ptr);
+int context_n_ctx_seq(void* state_ptr);
+int context_n_batch(void* state_ptr);
+int context_n_ubatch(void* state_ptr);
+int context_n_seq_max(void* state_ptr);
+int context_n_rs_seq(void* state_ptr);
+int context_pooling_type(void* state_ptr);
+int context_n_threads(void* state_ptr);
+int context_n_threads_batch(void* state_ptr);
+void context_set_n_threads(void* state_ptr, int n_threads, int n_threads_batch);
+void context_set_embeddings(void* state_ptr, bool embeddings);
+void context_set_causal_attn(void* state_ptr, bool causal_attn);
+void context_synchronize(void* state_ptr);
+
+// Further KV-cache operations. memory_seq_add shifts, and memory_seq_div
+// divides, the positions of a sequence in [p0, p1); negative p0/p1 mean "from
+// the start" / "to the end". The pos accessors return -1 for an empty sequence.
+void memory_seq_add(void* state_ptr, int seq_id, int p0, int p1, int delta);
+void memory_seq_div(void* state_ptr, int seq_id, int p0, int p1, int d);
+int memory_seq_pos_min(void* state_ptr, int seq_id);
+int memory_seq_pos_max(void* state_ptr, int seq_id);
+bool memory_can_shift(void* state_ptr);
+
+// Performance counters. Every out-parameter is optional (pass NULL to skip).
+// perf_sampler only reports data for samplers built with sampler_chain_init.
+void perf_context(void* state_ptr, double* t_start_ms, double* t_load_ms,
+                  double* t_p_eval_ms, double* t_eval_ms,
+                  int* n_p_eval, int* n_eval, int* n_reused);
+void perf_context_reset(void* state_ptr);
+void perf_sampler(void* smpl, double* t_sample_ms, int* n_sample);
+void perf_sampler_reset(void* smpl);
+
+// Library-level information, available without a loaded model.
+const char* llama_version_str(void);
+long long llama_time_us_val(void);
+
 // Composable samplers. Build a chain with sampler_chain_init, append stages
 // created by the sampler_init_* helpers with sampler_chain_add (the chain takes
 // ownership), then sampler_sample from a decoded context. sampler_free releases

--- a/llama.go
+++ b/llama.go
@@ -210,6 +210,217 @@ func (l *LLama) MemorySeqKeep(seqID int32) {
 	C.memory_seq_keep(l.state, C.int(seqID))
 }
 
+// MemorySeqAdd shifts the positions of tokens in [p0, p1) of sequence seqID by
+// delta. Pass p0 < 0 to start at 0 and p1 < 0 to run to the end. This is how a
+// context is "slid" forward after evicting a prefix; check MemoryCanShift first,
+// since not every cache type supports it.
+func (l *LLama) MemorySeqAdd(seqID, p0, p1, delta int32) {
+	C.memory_seq_add(l.state, C.int(seqID), C.int(p0), C.int(p1), C.int(delta))
+}
+
+// MemorySeqDiv integer-divides the positions of tokens in [p0, p1) of sequence
+// seqID by d (which must be > 1) — the position-interpolation trick for
+// stretching a context beyond its trained length.
+func (l *LLama) MemorySeqDiv(seqID, p0, p1 int32, d int) {
+	C.memory_seq_div(l.state, C.int(seqID), C.int(p0), C.int(p1), C.int(d))
+}
+
+// MemorySeqPosMin returns the smallest position held in the KV cache for
+// seqID, or -1 if the sequence is empty. It is non-zero only for caches that
+// evict from the front, such as sliding-window attention.
+func (l *LLama) MemorySeqPosMin(seqID int32) int32 {
+	return int32(C.memory_seq_pos_min(l.state, C.int(seqID)))
+}
+
+// MemorySeqPosMax returns the largest position held in the KV cache for seqID,
+// or -1 if the sequence is empty. Every position in
+// [MemorySeqPosMin, MemorySeqPosMax] is guaranteed to be present.
+func (l *LLama) MemorySeqPosMax(seqID int32) int32 {
+	return int32(C.memory_seq_pos_max(l.state, C.int(seqID)))
+}
+
+// MemoryCanShift reports whether the context's KV cache supports position
+// shifting via MemorySeqAdd.
+func (l *LLama) MemoryCanShift() bool {
+	return bool(C.memory_can_shift(l.state))
+}
+
+// PoolingType identifies how a context pools token embeddings into a single
+// sequence embedding.
+type PoolingType int
+
+// Pooling strategies, mirroring llama_pooling_type.
+const (
+	PoolingUnspecified PoolingType = -1
+	PoolingNone        PoolingType = 0
+	PoolingMean        PoolingType = 1
+	PoolingCLS         PoolingType = 2
+	PoolingLast        PoolingType = 3
+	PoolingRank        PoolingType = 4
+)
+
+// String returns the llama.cpp name of the pooling strategy.
+func (p PoolingType) String() string {
+	switch p {
+	case PoolingUnspecified:
+		return "unspecified"
+	case PoolingNone:
+		return "none"
+	case PoolingMean:
+		return "mean"
+	case PoolingCLS:
+		return "cls"
+	case PoolingLast:
+		return "last"
+	case PoolingRank:
+		return "rank"
+	default:
+		return fmt.Sprintf("PoolingType(%d)", int(p))
+	}
+}
+
+// ContextParams reports the geometry the context actually runs with. The engine
+// may clamp or round what New was asked for, so prefer these over the values in
+// ModelOptions when sizing batches or picking sequence ids.
+type ContextParams struct {
+	// NCtx is the total context size across all sequences.
+	NCtx int
+	// NCtxSeq is the per-sequence context size.
+	NCtxSeq int
+	// NBatch is the maximum number of tokens a single Decode may submit.
+	NBatch int
+	// NUbatch is the physical micro-batch size the graph is built for.
+	NUbatch int
+	// NSeqMax is the number of sequences the KV cache can hold, so valid
+	// sequence ids are [0, NSeqMax).
+	NSeqMax int
+	// NRSSeq is the number of recurrent-state sequences, for models with a
+	// recurrent (Mamba-style) memory.
+	NRSSeq int
+	// Pooling is the embedding pooling strategy.
+	Pooling PoolingType
+}
+
+// ContextParams returns the geometry of the loaded context.
+func (l *LLama) ContextParams() ContextParams {
+	return ContextParams{
+		NCtx:    int(C.context_n_ctx(l.state)),
+		NCtxSeq: int(C.context_n_ctx_seq(l.state)),
+		NBatch:  int(C.context_n_batch(l.state)),
+		NUbatch: int(C.context_n_ubatch(l.state)),
+		NSeqMax: int(C.context_n_seq_max(l.state)),
+		NRSSeq:  int(C.context_n_rs_seq(l.state)),
+		Pooling: PoolingType(C.context_pooling_type(l.state)),
+	}
+}
+
+// Threads returns the thread counts the context currently uses: nThreads for
+// single-token generation and nThreadsBatch for prompt and batch processing.
+func (l *LLama) Threads() (nThreads, nThreadsBatch int) {
+	return int(C.context_n_threads(l.state)), int(C.context_n_threads_batch(l.state))
+}
+
+// SetThreads changes the thread counts used for generation (nThreads) and for
+// prompt/batch processing (nThreadsBatch). It takes effect on the next decode.
+func (l *LLama) SetThreads(nThreads, nThreadsBatch int) {
+	C.context_set_n_threads(l.state, C.int(nThreads), C.int(nThreadsBatch))
+}
+
+// SetEmbeddings switches the context between producing logits and producing
+// embeddings. It also updates what Embeddings reports, so a model loaded with
+// EnableEmbeddings can be flipped back to generation and vice versa.
+func (l *LLama) SetEmbeddings(enabled bool) {
+	C.context_set_embeddings(l.state, C.bool(enabled))
+}
+
+// SetCausalAttn selects causal (each token attends only to the past) or
+// non-causal attention. Encoder-style embedding models want non-causal.
+func (l *LLama) SetCausalAttn(causal bool) {
+	C.context_set_causal_attn(l.state, C.bool(causal))
+}
+
+// Synchronize blocks until all queued computation on the context has finished.
+// The output accessors do this for you; it is only needed when timing manually.
+func (l *LLama) Synchronize() {
+	C.context_synchronize(l.state)
+}
+
+// Perf holds llama.cpp's context-level performance counters.
+//
+// The engine skips its own timing calls unless asked; the binding enables
+// them when it creates the context, so these are populated rather than zero.
+//
+// PromptTokens and EvalTokens have a floor of 1: the engine clamps them so its
+// own reporting can divide by them without guarding against zero. A context
+// that has decoded nothing, or one just reset by PerfReset, therefore reports 1
+// rather than 0, and the two cases cannot be told apart. Use the timings to
+// decide whether any work has actually happened.
+type Perf struct {
+	// StartMS is the absolute start time in milliseconds.
+	StartMS float64
+	// LoadMS is the time spent loading the model.
+	LoadMS float64
+	// PromptEvalMS is the time spent processing prompt tokens.
+	PromptEvalMS float64
+	// EvalMS is the time spent generating tokens.
+	EvalMS float64
+	// PromptTokens is the number of prompt tokens processed, floored at 1.
+	PromptTokens int
+	// EvalTokens is the number of tokens generated, floored at 1.
+	EvalTokens int
+	// GraphsReused is the number of times a compute graph was reused.
+	GraphsReused int
+}
+
+// Perf returns the context's performance counters, accumulated since load or
+// since the last PerfReset.
+func (l *LLama) Perf() Perf {
+	var tStart, tLoad, tPEval, tEval C.double
+	var nPEval, nEval, nReused C.int
+	C.perf_context(l.state, &tStart, &tLoad, &tPEval, &tEval, &nPEval, &nEval, &nReused)
+	return Perf{
+		StartMS:      float64(tStart),
+		LoadMS:       float64(tLoad),
+		PromptEvalMS: float64(tPEval),
+		EvalMS:       float64(tEval),
+		PromptTokens: int(nPEval),
+		EvalTokens:   int(nEval),
+		GraphsReused: int(nReused),
+	}
+}
+
+// PerfReset restarts the context's performance counters. Timings go back to
+// zero; the token counts return to their floor of 1, not 0 (see Perf).
+func (l *LLama) PerfReset() { C.perf_context_reset(l.state) }
+
+// SamplerPerf holds a sampler chain's performance counters.
+type SamplerPerf struct {
+	// SampleMS is the time spent sampling, in milliseconds.
+	SampleMS float64
+	// Samples is the number of tokens sampled.
+	Samples int
+}
+
+// Perf returns the chain's sampling counters. It reports zeroes for a stage
+// that was not created by NewSamplerChain.
+func (s *Sampler) Perf() SamplerPerf {
+	var tSample C.double
+	var nSample C.int
+	C.perf_sampler(s.ptr, &tSample, &nSample)
+	return SamplerPerf{SampleMS: float64(tSample), Samples: int(nSample)}
+}
+
+// PerfReset zeroes the chain's sampling counters.
+func (s *Sampler) PerfReset() { C.perf_sampler_reset(s.ptr) }
+
+// Version returns the version string of the linked llama.cpp library.
+func Version() string { return C.GoString(C.llama_version_str()) }
+
+// TimeUS returns llama.cpp's monotonic clock in microseconds. It shares a time
+// base with the values in Perf, so it is the right clock for measuring spans
+// that are compared against them.
+func TimeUS() int64 { return int64(C.llama_time_us_val()) }
+
 // Sampler is a single sampling stage or a chain of stages, wrapping llama.cpp's
 // sampler API. Construct stages (SamplerTopK, SamplerTemp, ...), add them to a
 // chain from NewSamplerChain, then Sample from a decoded context.

--- a/llama_test.go
+++ b/llama_test.go
@@ -320,6 +320,128 @@ how much is 2+2?
 		})
 	})
 
+	Context("Library information", func() {
+		It("reports a llama.cpp version", func() {
+			Expect(Version()).ToNot(BeEmpty())
+		})
+
+		It("exposes a monotonic clock", func() {
+			t0 := TimeUS()
+			Expect(t0).To(BeNumerically(">", int64(0)))
+			Expect(TimeUS()).To(BeNumerically(">=", t0))
+		})
+	})
+
+	Context("Context introspection and control", func() {
+		It("reports the geometry the context actually uses", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			p := model.ContextParams()
+			Expect(p.NCtx).To(BeNumerically(">", 0))
+			Expect(p.NCtxSeq).To(BeNumerically(">", 0))
+			Expect(p.NCtxSeq).To(BeNumerically("<=", p.NCtx))
+			Expect(p.NBatch).To(BeNumerically(">", 0))
+			Expect(p.NUbatch).To(BeNumerically(">", 0))
+			Expect(p.NUbatch).To(BeNumerically("<=", p.NBatch))
+			Expect(p.NSeqMax).To(BeNumerically(">=", 1))
+			Expect(p.NRSSeq).To(BeNumerically(">=", 0))
+			Expect(p.Pooling.String()).ToNot(BeEmpty())
+		})
+
+		It("round-trips the thread counts", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			model.SetThreads(2, 3)
+			gen, batch := model.Threads()
+			Expect(gen).To(Equal(2))
+			Expect(batch).To(Equal(3))
+		})
+
+		It("tracks KV-cache sequence positions across a decode", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			model.MemoryClear(true)
+			Expect(model.MemorySeqPosMax(0)).To(Equal(int32(-1)), "cache should be empty after a clear")
+
+			tokens := model.Tokenize("The capital of France is", true, false)
+			Expect(tokens).ToNot(BeEmpty())
+
+			batch := NewBatch(len(tokens), 1)
+			defer batch.Free()
+			for i, tok := range tokens {
+				Expect(batch.Add(tok, int32(i), []int32{0}, i == len(tokens)-1)).To(Succeed())
+			}
+			Expect(model.Decode(batch)).To(Equal(0))
+
+			Expect(model.MemorySeqPosMin(0)).To(BeNumerically(">=", int32(0)))
+			Expect(model.MemorySeqPosMax(0)).To(Equal(int32(len(tokens) - 1)))
+
+			// The standard context-shift idiom: evict the oldest token, then
+			// slide the remainder back so positions stay contiguous from 0.
+			// Not every cache type supports it.
+			if model.MemoryCanShift() {
+				Expect(model.MemorySeqRemove(0, 0, 1)).To(BeTrue())
+				model.MemorySeqAdd(0, 1, -1, -1)
+				Expect(model.MemorySeqPosMin(0)).To(Equal(int32(0)))
+				Expect(model.MemorySeqPosMax(0)).To(Equal(int32(len(tokens) - 2)))
+			}
+
+			model.MemorySeqKeep(0)
+			Expect(model.MemorySeqPosMax(1)).To(Equal(int32(-1)))
+		})
+
+		It("accumulates and resets performance counters", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			_, err = model.Predict("The capital of France is", SetTokens(8))
+			Expect(err).ToNot(HaveOccurred())
+
+			perf := model.Perf()
+			Expect(perf.LoadMS).To(BeNumerically(">", 0))
+			// The binding turns off no_perf, so the engine actually records
+			// timings; a multi-token prompt decode lands in the prompt-eval
+			// bucket and a generated token in the eval bucket.
+			Expect(perf.PromptEvalMS).To(BeNumerically(">", 0))
+			Expect(perf.PromptTokens).To(BeNumerically(">", 1))
+			Expect(perf.EvalMS).To(BeNumerically(">", 0))
+
+			model.PerfReset()
+			reset := model.Perf()
+			Expect(reset.PromptEvalMS).To(BeNumerically("==", 0))
+			Expect(reset.EvalMS).To(BeNumerically("==", 0))
+			// llama.cpp floors these counters at 1 so its own reporting can
+			// divide by them, so a reset context reports 1 rather than 0.
+			Expect(reset.PromptTokens).To(Equal(1))
+			Expect(reset.EvalTokens).To(Equal(1))
+			// Load time survives a reset; only the eval counters restart.
+			Expect(reset.LoadMS).To(Equal(perf.LoadMS))
+		})
+	})
+
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {
 		getModel := func() (*LLama, error) {
 			model, err := New(


### PR DESCRIPTION
Stacked on #206 (the v0.3.0 build fix) — review that one first; the base retargets to `main` once it merges.

Part of the engine-parity work. An audit of `llama.h` at v0.3.0 found **105 live (non-deprecated) engine functions with no Go surface at all**. This PR closes the first group of them.

## Context geometry and control

The engine clamps and rounds what `llama_context_params` asks for, and upstream explicitly recommends reading back the real values ([ggml-org/llama.cpp#17046](https://github.com/ggml-org/llama.cpp/pull/17046)). There was no way to do that from Go:

```go
p := model.ContextParams()   // NCtx, NCtxSeq, NBatch, NUbatch, NSeqMax, NRSSeq, Pooling
gen, batch := model.Threads()
model.SetThreads(8, 16)
model.SetEmbeddings(true)
model.SetCausalAttn(false)
model.Synchronize()
```

`PoolingType` is a typed enum with a `String` method rather than a bare int.

## KV-cache operations

`MemorySeqAdd` / `MemorySeqDiv` / `MemorySeqPosMin` / `MemorySeqPosMax` / `MemoryCanShift` complete the set started in #183. Together they make **context shifting** expressible for the first time — evict a prefix, then slide the remainder back so positions stay contiguous:

```go
if model.MemoryCanShift() {
    model.MemorySeqRemove(0, 0, nDiscard)
    model.MemorySeqAdd(0, nDiscard, -1, -nDiscard)
}
```

The test exercises exactly that idiom against a real decode.

## Performance counters

`Perf()` / `PerfReset()` on the context and on a sampler chain. Previously the only way to see prompt-eval and eval timings was to scrape llama.cpp's stderr.

Package-level `Version()` and `TimeUS()` round it out. `TimeUS` shares a time base with the `Perf` fields, so it is the correct clock for spans measured against them.

## Engine APIs newly covered (22)

`llama_n_ctx_seq`, `llama_n_batch`, `llama_n_ubatch`, `llama_n_seq_max`, `llama_n_rs_seq`, `llama_pooling_type`, `llama_n_threads`, `llama_n_threads_batch`, `llama_set_n_threads`, `llama_set_embeddings`, `llama_set_causal_attn`, `llama_synchronize`, `llama_memory_seq_add`, `llama_memory_seq_div`, `llama_memory_seq_pos_min`, `llama_memory_seq_pos_max`, `llama_memory_can_shift`, `llama_perf_context`, `llama_perf_context_reset`, `llama_perf_sampler`, `llama_perf_sampler_reset`, `llama_version`, `llama_time_us`

## Verification

`binding.cpp` compiles clean under the full CI flag set; `go vet` and `gofmt` clean. New tests live in their own `Context` blocks; the model-gated ones skip without `TEST_MODEL`, and `Version`/`TimeUS` are covered unconditionally.