### PR TITLE
feat: vocabulary and model architecture introspection

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -1421,3 +1421,210 @@ int chat_builtin_template_name(int i, char* buf, int buf_size) {
     }
     return snprintf(buf, (size_t) buf_size, "%s", names[(size_t) i]);
 }
+
+//
+// Vocabulary introspection
+//
+
+int get_vocab_type(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_vocab_type(llama_model_get_vocab(state->model));
+}
+
+// Returns the raw vocabulary entry for a token: the stored piece, before any
+// byte-fallback or SentencePiece space decoding. Use token_to_piece_str for
+// text that can be concatenated into output.
+int get_vocab_token_text(void* state_ptr, int token, char* buf, int buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    if (token < 0 || token >= llama_vocab_n_tokens(vocab)) {
+        return -1;
+    }
+    const char* text = llama_vocab_get_text(vocab, token);
+    if (text == nullptr) {
+        return -1;
+    }
+    return snprintf(buf, (size_t) buf_size, "%s", text);
+}
+
+float get_vocab_token_score(void* state_ptr, int token) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    if (token < 0 || token >= llama_vocab_n_tokens(vocab)) {
+        return 0.0f;
+    }
+    return llama_vocab_get_score(vocab, token);
+}
+
+int get_vocab_token_attr(void* state_ptr, int token) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    if (token < 0 || token >= llama_vocab_n_tokens(vocab)) {
+        return 0;  // LLAMA_TOKEN_ATTR_UNDEFINED
+    }
+    return (int) llama_vocab_get_attr(vocab, token);
+}
+
+bool vocab_token_is_eog(void* state_ptr, int token) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    if (token < 0 || token >= llama_vocab_n_tokens(vocab)) {
+        return false;
+    }
+    return llama_vocab_is_eog(vocab, token);
+}
+
+bool vocab_token_is_control(void* state_ptr, int token) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    if (token < 0 || token >= llama_vocab_n_tokens(vocab)) {
+        return false;
+    }
+    return llama_vocab_is_control(vocab, token);
+}
+
+bool get_vocab_add_sep(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_vocab_get_add_sep(llama_model_get_vocab(state->model));
+}
+
+// Copies the vocabulary's suppress list into tokens_out. Returns the number of
+// suppressed tokens, or the negative of that count when max_tokens is too
+// small, matching the convention used by tokenize_text.
+int get_vocab_suppress_tokens(void* state_ptr, int* tokens_out, int max_tokens) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    int32_t n = 0;
+    const llama_token* toks = llama_vocab_get_suppress_tokens(vocab, &n);
+    if (toks == nullptr || n <= 0) {
+        return 0;
+    }
+    if (n > max_tokens) {
+        return -n;
+    }
+    for (int32_t i = 0; i < n; i++) {
+        tokens_out[i] = toks[i];
+    }
+    return n;
+}
+
+//
+// Further model introspection
+//
+
+int get_model_rope_type(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_model_rope_type(state->model);
+}
+
+int get_model_ftype(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_model_ftype(state->model);
+}
+
+int get_model_decoder_start_token(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_decoder_start_token(state->model);
+}
+
+int get_model_n_embd_inp(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_n_embd_inp(state->model);
+}
+
+int get_model_n_embd_out(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_n_embd_out(state->model);
+}
+
+int get_model_n_layer_nextn(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_n_layer_nextn(state->model);
+}
+
+int get_model_n_cls_out(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) llama_model_n_cls_out(state->model);
+}
+
+int get_model_cls_label(void* state_ptr, int i, char* buf, int buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (i < 0 || (uint32_t) i >= llama_model_n_cls_out(state->model)) {
+        return -1;
+    }
+    const char* label = llama_model_cls_label(state->model, (uint32_t) i);
+    if (label == nullptr) {
+        return -1;
+    }
+    return snprintf(buf, (size_t) buf_size, "%s", label);
+}
+
+bool model_is_hybrid(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_is_hybrid(state->model);
+}
+
+bool model_is_diffusion(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_model_is_diffusion(state->model);
+}
+
+// Names for enum values, independent of any loaded model.
+int ftype_name(int ftype, char* buf, int buf_size) {
+    const char* name = llama_ftype_name((enum llama_ftype) ftype);
+    if (name == nullptr) {
+        return -1;
+    }
+    return snprintf(buf, (size_t) buf_size, "%s", name);
+}
+
+int flash_attn_type_name(int type, char* buf, int buf_size) {
+    const char* name = llama_flash_attn_type_name((enum llama_flash_attn_type) type);
+    if (name == nullptr) {
+        return -1;
+    }
+    return snprintf(buf, (size_t) buf_size, "%s", name);
+}
+
+//
+// Guards for the enum values mirrored in llama.go.
+//
+// The Go layer declares PoolingType, VocabType, TokenAttr and RopeType as
+// typed constants so callers get real names instead of bare ints. Those values
+// are copies, so if llama.cpp ever renumbers an enum the Go names would keep
+// compiling while silently decoding to the wrong thing. These assertions make
+// that a build failure here instead.
+
+static_assert(LLAMA_POOLING_TYPE_UNSPECIFIED == -1, "PoolingUnspecified out of sync with llama.go");
+static_assert(LLAMA_POOLING_TYPE_NONE        ==  0, "PoolingNone out of sync with llama.go");
+static_assert(LLAMA_POOLING_TYPE_MEAN        ==  1, "PoolingMean out of sync with llama.go");
+static_assert(LLAMA_POOLING_TYPE_CLS         ==  2, "PoolingCLS out of sync with llama.go");
+static_assert(LLAMA_POOLING_TYPE_LAST        ==  3, "PoolingLast out of sync with llama.go");
+static_assert(LLAMA_POOLING_TYPE_RANK        ==  4, "PoolingRank out of sync with llama.go");
+
+static_assert(LLAMA_VOCAB_TYPE_NONE   == 0, "VocabNone out of sync with llama.go");
+static_assert(LLAMA_VOCAB_TYPE_SPM    == 1, "VocabSPM out of sync with llama.go");
+static_assert(LLAMA_VOCAB_TYPE_BPE    == 2, "VocabBPE out of sync with llama.go");
+static_assert(LLAMA_VOCAB_TYPE_WPM    == 3, "VocabWPM out of sync with llama.go");
+static_assert(LLAMA_VOCAB_TYPE_UGM    == 4, "VocabUGM out of sync with llama.go");
+static_assert(LLAMA_VOCAB_TYPE_RWKV   == 5, "VocabRWKV out of sync with llama.go");
+static_assert(LLAMA_VOCAB_TYPE_PLAMO2 == 6, "VocabPLaMo2 out of sync with llama.go");
+
+static_assert(LLAMA_TOKEN_ATTR_UNDEFINED    == 0,      "TokenAttrUndefined out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_UNKNOWN      == 1 << 0, "TokenAttrUnknown out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_UNUSED       == 1 << 1, "TokenAttrUnused out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_NORMAL       == 1 << 2, "TokenAttrNormal out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_CONTROL      == 1 << 3, "TokenAttrControl out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_USER_DEFINED == 1 << 4, "TokenAttrUserDefined out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_BYTE         == 1 << 5, "TokenAttrByte out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_NORMALIZED   == 1 << 6, "TokenAttrNormalized out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_LSTRIP       == 1 << 7, "TokenAttrLStrip out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_RSTRIP       == 1 << 8, "TokenAttrRStrip out of sync with llama.go");
+static_assert(LLAMA_TOKEN_ATTR_SINGLE_WORD  == 1 << 9, "TokenAttrSingleWord out of sync with llama.go");
+
+static_assert(LLAMA_ROPE_TYPE_NONE   == -1, "RopeNone out of sync with llama.go");
+static_assert(LLAMA_ROPE_TYPE_NORM   ==  0, "RopeNorm out of sync with llama.go");
+static_assert(LLAMA_ROPE_TYPE_NEOX   ==  2, "RopeNeox out of sync with llama.go");
+static_assert(LLAMA_ROPE_TYPE_MROPE  ==  8, "RopeMrope out of sync with llama.go");
+static_assert(LLAMA_ROPE_TYPE_VISION == 24, "RopeVision out of sync with llama.go");
+static_assert(LLAMA_ROPE_TYPE_IMROPE == 40, "RopeImrope out of sync with llama.go");

--- a/binding.h
+++ b/binding.h
@@ -151,6 +151,38 @@ int get_vocab_fim_pad(void* state_ptr);
 int get_vocab_fim_rep(void* state_ptr);
 int get_vocab_fim_sep(void* state_ptr);
 
+
+// Vocabulary introspection. The *_str-style functions follow snprintf
+// semantics (see above) and return -1 for an out-of-range token.
+// get_vocab_token_text returns the raw stored vocabulary entry, which is not
+// the same as printable text -- use token_to_piece_str for output.
+// get_vocab_token_attr returns a bitmask of llama_token_attr values.
+int get_vocab_type(void* state_ptr);
+int get_vocab_token_text(void* state_ptr, int token, char* buf, int buf_size);
+float get_vocab_token_score(void* state_ptr, int token);
+int get_vocab_token_attr(void* state_ptr, int token);
+bool vocab_token_is_eog(void* state_ptr, int token);
+bool vocab_token_is_control(void* state_ptr, int token);
+bool get_vocab_add_sep(void* state_ptr);
+int get_vocab_suppress_tokens(void* state_ptr, int* tokens_out, int max_tokens);
+
+// Further model introspection. get_model_cls_label names the i-th output of a
+// classifier head; get_model_decoder_start_token returns -1 when the model is
+// not an encoder-decoder. ftype_name and flash_attn_type_name translate enum
+// values to strings and need no loaded model.
+int get_model_rope_type(void* state_ptr);
+int get_model_ftype(void* state_ptr);
+int get_model_decoder_start_token(void* state_ptr);
+int get_model_n_embd_inp(void* state_ptr);
+int get_model_n_embd_out(void* state_ptr);
+int get_model_n_layer_nextn(void* state_ptr);
+int get_model_n_cls_out(void* state_ptr);
+int get_model_cls_label(void* state_ptr, int i, char* buf, int buf_size);
+bool model_is_hybrid(void* state_ptr);
+bool model_is_diffusion(void* state_ptr);
+int ftype_name(int ftype, char* buf, int buf_size);
+int flash_attn_type_name(int type, char* buf, int buf_size);
+
 // Model architecture queries
 bool model_has_encoder(void* state_ptr);
 bool model_has_decoder(void* state_ptr);

--- a/llama.go
+++ b/llama.go
@@ -545,6 +545,298 @@ func (l *LLama) GetModelInfo() ModelInfo {
 	}
 }
 
+// VocabType identifies the tokenizer family a model's vocabulary uses.
+type VocabType int
+
+// Tokenizer families, mirroring llama_vocab_type.
+const (
+	VocabNone   VocabType = 0 // model carries no vocabulary
+	VocabSPM    VocabType = 1 // SentencePiece: byte-level BPE with byte fallback
+	VocabBPE    VocabType = 2 // GPT-2 style byte-level BPE
+	VocabWPM    VocabType = 3 // BERT WordPiece
+	VocabUGM    VocabType = 4 // T5 Unigram
+	VocabRWKV   VocabType = 5 // RWKV greedy tokenization
+	VocabPLaMo2 VocabType = 6 // PLaMo-2 Aho-Corasick
+)
+
+// String returns the llama.cpp name of the tokenizer family.
+func (v VocabType) String() string {
+	switch v {
+	case VocabNone:
+		return "none"
+	case VocabSPM:
+		return "spm"
+	case VocabBPE:
+		return "bpe"
+	case VocabWPM:
+		return "wpm"
+	case VocabUGM:
+		return "ugm"
+	case VocabRWKV:
+		return "rwkv"
+	case VocabPLaMo2:
+		return "plamo2"
+	default:
+		return fmt.Sprintf("VocabType(%d)", int(v))
+	}
+}
+
+// TokenAttr is a bitmask describing how a token behaves during tokenization.
+type TokenAttr int
+
+// Token attributes, mirroring llama_token_attr. Test them with Has.
+const (
+	TokenAttrUndefined   TokenAttr = 0
+	TokenAttrUnknown     TokenAttr = 1 << 0
+	TokenAttrUnused      TokenAttr = 1 << 1
+	TokenAttrNormal      TokenAttr = 1 << 2
+	TokenAttrControl     TokenAttr = 1 << 3
+	TokenAttrUserDefined TokenAttr = 1 << 4
+	TokenAttrByte        TokenAttr = 1 << 5
+	TokenAttrNormalized  TokenAttr = 1 << 6
+	TokenAttrLStrip      TokenAttr = 1 << 7
+	TokenAttrRStrip      TokenAttr = 1 << 8
+	TokenAttrSingleWord  TokenAttr = 1 << 9
+)
+
+// Has reports whether every bit of attr is set.
+func (a TokenAttr) Has(attr TokenAttr) bool { return a&attr == attr }
+
+// String renders the set bits as a pipe-joined list.
+func (a TokenAttr) String() string {
+	if a == TokenAttrUndefined {
+		return "undefined"
+	}
+	names := []struct {
+		bit  TokenAttr
+		name string
+	}{
+		{TokenAttrUnknown, "unknown"},
+		{TokenAttrUnused, "unused"},
+		{TokenAttrNormal, "normal"},
+		{TokenAttrControl, "control"},
+		{TokenAttrUserDefined, "user_defined"},
+		{TokenAttrByte, "byte"},
+		{TokenAttrNormalized, "normalized"},
+		{TokenAttrLStrip, "lstrip"},
+		{TokenAttrRStrip, "rstrip"},
+		{TokenAttrSingleWord, "single_word"},
+	}
+	var set []string
+	for _, n := range names {
+		if a&n.bit != 0 {
+			set = append(set, n.name)
+		}
+	}
+	if len(set) == 0 {
+		return fmt.Sprintf("TokenAttr(%d)", int(a))
+	}
+	return strings.Join(set, "|")
+}
+
+// VocabType returns the tokenizer family of the model's vocabulary.
+func (l *LLama) VocabType() VocabType {
+	return VocabType(C.get_vocab_type(l.state))
+}
+
+// TokenText returns the raw vocabulary entry for token: the piece exactly as
+// the tokenizer stores it, which for SPM models still carries the U+2581 word
+// boundary marker and for BPE models the byte-level escapes. It is the right
+// thing for inspecting a vocabulary and the wrong thing for building output:
+// use TokenToPiece for text you intend to concatenate.
+//
+// It returns "" for a token outside the vocabulary.
+func (l *LLama) TokenText(token int32) string {
+	buf := make([]byte, 256)
+	ret := int(C.get_vocab_token_text(l.state, C.int(token),
+		(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+	if ret <= 0 {
+		return ""
+	}
+	if ret > len(buf) {
+		buf = make([]byte, ret+1)
+		ret = int(C.get_vocab_token_text(l.state, C.int(token),
+			(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+		if ret <= 0 || ret > len(buf) {
+			return ""
+		}
+	}
+	return string(buf[:ret])
+}
+
+// TokenScore returns the vocabulary score for token, used by SPM and UGM
+// tokenizers to choose between competing merges. It is 0 for tokenizers that
+// do not use scores and for a token outside the vocabulary.
+func (l *LLama) TokenScore(token int32) float32 {
+	return float32(C.get_vocab_token_score(l.state, C.int(token)))
+}
+
+// TokenAttr returns the attribute bitmask for token, or TokenAttrUndefined for
+// a token outside the vocabulary.
+func (l *LLama) TokenAttr(token int32) TokenAttr {
+	return TokenAttr(C.get_vocab_token_attr(l.state, C.int(token)))
+}
+
+// IsEOG reports whether token ends generation. This covers every end-of-turn
+// and end-of-sequence token the model defines, not only EOS, and is what a
+// generation loop should actually test against.
+func (l *LLama) IsEOG(token int32) bool {
+	return bool(C.vocab_token_is_eog(l.state, C.int(token)))
+}
+
+// IsControlToken reports whether token is a control token rather than text.
+func (l *LLama) IsControlToken(token int32) bool {
+	return bool(C.vocab_token_is_control(l.state, C.int(token)))
+}
+
+// AddSeparator reports whether the tokenizer inserts a separator token: the
+// SEP counterpart to the BOS and EOS flags in SpecialTokens.
+func (l *LLama) AddSeparator() bool {
+	return bool(C.get_vocab_add_sep(l.state))
+}
+
+// SuppressTokens returns the tokens the model's vocabulary marks as never to
+// be generated. It returns nil when the vocabulary suppresses nothing.
+func (l *LLama) SuppressTokens() []int32 {
+	n := int(C.get_vocab_suppress_tokens(l.state, nil, 0))
+	if n == 0 {
+		return nil
+	}
+	if n < 0 {
+		n = -n
+	}
+	out := make([]int32, n)
+	got := int(C.get_vocab_suppress_tokens(l.state,
+		(*C.int)(unsafe.Pointer(&out[0])), C.int(n)))
+	if got <= 0 {
+		return nil
+	}
+	return out[:got]
+}
+
+// RopeType identifies the rotary position embedding variant a model uses.
+type RopeType int
+
+// RoPE variants, mirroring llama_rope_type. The values past NORM come from
+// ggml and are deliberately not a contiguous range.
+const (
+	RopeNone   RopeType = -1
+	RopeNorm   RopeType = 0
+	RopeNeox   RopeType = 2
+	RopeMrope  RopeType = 8
+	RopeVision RopeType = 24
+	RopeImrope RopeType = 40
+)
+
+// String returns a short name for the RoPE variant.
+func (r RopeType) String() string {
+	switch r {
+	case RopeNone:
+		return "none"
+	case RopeNorm:
+		return "norm"
+	case RopeNeox:
+		return "neox"
+	case RopeMrope:
+		return "mrope"
+	case RopeVision:
+		return "vision"
+	case RopeImrope:
+		return "imrope"
+	default:
+		return fmt.Sprintf("RopeType(%d)", int(r))
+	}
+}
+
+// Architecture describes structural properties of the loaded model that decide
+// how it has to be driven: which graph halves exist, how positions are encoded,
+// and how it was quantized.
+type Architecture struct {
+	// RopeType is the rotary position embedding variant.
+	RopeType RopeType
+	// FileType is the llama_ftype the model was quantized to.
+	FileType int
+	// FileTypeName is the engine's name for FileType, e.g. "Q4_K - Medium".
+	FileTypeName string
+	// HasEncoder and HasDecoder report which halves of an encoder-decoder
+	// model are present.
+	HasEncoder bool
+	HasDecoder bool
+	// DecoderStartToken opens decoding on an encoder-decoder model, or is -1
+	// when the model defines none.
+	DecoderStartToken int32
+	// IsRecurrent is true for recurrent (Mamba-style) models, which keep a
+	// rolling state instead of a growing KV cache.
+	IsRecurrent bool
+	// IsHybrid is true for models that mix attention and recurrent layers.
+	IsHybrid bool
+	// IsDiffusion is true for diffusion language models, which do not
+	// generate strictly left to right.
+	IsDiffusion bool
+	// EmbdInp and EmbdOut are the input and output embedding widths. They
+	// differ from ModelInfo.EmbeddingSize on models with a projection.
+	EmbdInp int
+	EmbdOut int
+	// LayersNextN is the number of multi-token-prediction layers, 0 when the
+	// model has none.
+	LayersNextN int
+	// ClassifierLabels names the outputs of a classifier head, nil for a
+	// model without one.
+	ClassifierLabels []string
+}
+
+// Architecture returns the structural properties of the loaded model.
+func (l *LLama) Architecture() Architecture {
+	a := Architecture{
+		RopeType:          RopeType(C.get_model_rope_type(l.state)),
+		FileType:          int(C.get_model_ftype(l.state)),
+		HasEncoder:        bool(C.model_has_encoder(l.state)),
+		HasDecoder:        bool(C.model_has_decoder(l.state)),
+		DecoderStartToken: int32(C.get_model_decoder_start_token(l.state)),
+		IsRecurrent:       bool(C.model_is_recurrent(l.state)),
+		IsHybrid:          bool(C.model_is_hybrid(l.state)),
+		IsDiffusion:       bool(C.model_is_diffusion(l.state)),
+		EmbdInp:           int(C.get_model_n_embd_inp(l.state)),
+		EmbdOut:           int(C.get_model_n_embd_out(l.state)),
+		LayersNextN:       int(C.get_model_n_layer_nextn(l.state)),
+	}
+	a.FileTypeName = FileTypeName(a.FileType)
+
+	if n := int(C.get_model_n_cls_out(l.state)); n > 0 {
+		buf := make([]byte, 128)
+		for i := 0; i < n; i++ {
+			ret := int(C.get_model_cls_label(l.state, C.int(i),
+				(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+			if ret <= 0 || ret > len(buf) {
+				continue
+			}
+			a.ClassifierLabels = append(a.ClassifierLabels, string(buf[:ret]))
+		}
+	}
+	return a
+}
+
+// FileTypeName returns llama.cpp's name for a llama_ftype value, for example
+// "Q4_K - Medium". It returns "" for an unrecognised value.
+func FileTypeName(ftype int) string {
+	buf := make([]byte, 128)
+	ret := int(C.ftype_name(C.int(ftype), (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+	if ret <= 0 || ret > len(buf) {
+		return ""
+	}
+	return string(buf[:ret])
+}
+
+// FlashAttnTypeName returns llama.cpp's name for a llama_flash_attn_type value.
+func FlashAttnTypeName(t int) string {
+	buf := make([]byte, 128)
+	ret := int(C.flash_attn_type_name(C.int(t), (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+	if ret <= 0 || ret > len(buf) {
+		return ""
+	}
+	return string(buf[:ret])
+}
+
 // ModelMetadata returns every key-value entry stored in the GGUF model header
 // (architecture, tokenizer settings, quantization, and so on).
 func (l *LLama) ModelMetadata() map[string]string {

--- a/llama_test.go
+++ b/llama_test.go
@@ -535,6 +535,102 @@ how much is 2+2?
 		})
 	})
 
+	Context("Vocabulary and architecture introspection", func() {
+		newModel := func() *LLama {
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(model).ToNot(BeNil())
+			return model
+		}
+
+		It("names enum values without a model", func() {
+			// LLAMA_FTYPE_ALL_F32 == 0 is stable across every llama.cpp release.
+			Expect(FileTypeName(0)).ToNot(BeEmpty())
+			Expect(VocabSPM.String()).To(Equal("spm"))
+			Expect(RopeNeox.String()).To(Equal("neox"))
+			Expect(PoolingMean.String()).To(Equal("mean"))
+		})
+
+		It("renders token attribute bitmasks", func() {
+			a := TokenAttrControl | TokenAttrByte
+			Expect(a.Has(TokenAttrControl)).To(BeTrue())
+			Expect(a.Has(TokenAttrByte)).To(BeTrue())
+			Expect(a.Has(TokenAttrNormal)).To(BeFalse())
+			Expect(a.Has(TokenAttrControl | TokenAttrByte)).To(BeTrue())
+			Expect(a.String()).To(Equal("control|byte"))
+			Expect(TokenAttrUndefined.String()).To(Equal("undefined"))
+		})
+
+		It("reports the tokenizer family", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			Expect(model.VocabType()).ToNot(Equal(VocabNone))
+			Expect(model.VocabType().String()).ToNot(ContainSubstring("VocabType("))
+		})
+
+		It("describes individual tokens", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			special := model.GetSpecialTokens()
+			Expect(special.EOS).To(BeNumerically(">=", int32(0)))
+
+			// EOS must both be a control token and end generation.
+			Expect(model.TokenText(special.EOS)).ToNot(BeEmpty())
+			Expect(model.IsEOG(special.EOS)).To(BeTrue())
+			Expect(model.IsControlToken(special.EOS)).To(BeTrue())
+			Expect(model.TokenAttr(special.EOS).Has(TokenAttrControl)).To(BeTrue())
+
+			// A plain word token must not.
+			toks := model.Tokenize("hello", false, false)
+			Expect(toks).ToNot(BeEmpty())
+			Expect(model.IsEOG(toks[0])).To(BeFalse())
+			Expect(model.IsControlToken(toks[0])).To(BeFalse())
+			Expect(model.TokenText(toks[0])).ToNot(BeEmpty())
+		})
+
+		It("rejects out-of-range tokens instead of reading past the vocabulary", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			for _, bad := range []int32{-1, int32(model.GetModelInfo().VocabSize), 1 << 30} {
+				Expect(model.TokenText(bad)).To(BeEmpty())
+				Expect(model.TokenScore(bad)).To(Equal(float32(0)))
+				Expect(model.TokenAttr(bad)).To(Equal(TokenAttrUndefined))
+				Expect(model.IsEOG(bad)).To(BeFalse())
+				Expect(model.IsControlToken(bad)).To(BeFalse())
+			}
+		})
+
+		It("reports the model architecture", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			arch := model.Architecture()
+			// A decoder-only causal LM: decoder present, encoder absent.
+			Expect(arch.HasDecoder).To(BeTrue())
+			Expect(arch.HasEncoder).To(BeFalse())
+			Expect(arch.RopeType).ToNot(Equal(RopeNone))
+			Expect(arch.FileTypeName).ToNot(BeEmpty())
+			Expect(arch.EmbdInp).To(BeNumerically(">", 0))
+			Expect(arch.EmbdOut).To(BeNumerically(">", 0))
+			Expect(arch.FileTypeName).To(Equal(FileTypeName(arch.FileType)))
+		})
+	})
+
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {
 		getModel := func() (*LLama, error) {
 			model, err := New(


### PR DESCRIPTION
Stacked on #208 -> #207 -> #206.

Adds the per-token vocabulary accessors and the structural model queries. Both groups were entirely absent from the Go surface.

## Vocabulary

```go
model.VocabType()       // spm / bpe / wpm / ugm / rwkv / plamo2
model.TokenText(tok)    // raw stored vocabulary entry
model.TokenScore(tok)   // merge score, for SPM and UGM
model.TokenAttr(tok)    // control | byte | lstrip | ...
model.IsEOG(tok)        // ends generation
model.IsControlToken(tok)
model.AddSeparator()
model.SuppressTokens()
```

**`IsEOG` is the one that matters.** A generation loop that stops on `EOS` alone is wrong for any model defining several end-of-turn tokens — and until now the binding gave callers no way to ask the vocabulary the right question.

`TokenText` is deliberately *not* `TokenToPiece`, and its doc comment says so: it returns the entry as stored, still carrying SPM's U+2581 boundary marker and BPE's byte escapes. It is for inspecting a vocabulary, not for building output.

## Architecture

```go
arch := model.Architecture()
// RopeType, FileType/FileTypeName, HasEncoder/HasDecoder, DecoderStartToken,
// IsRecurrent/IsHybrid/IsDiffusion, EmbdInp/EmbdOut, LayersNextN, ClassifierLabels
```

These are the queries that decide how a model must be driven at all: whether to run an encoder pass, whether the KV cache grows, whether generation is even left-to-right.

## Mirrored enums are now guarded by the compiler

`PoolingType`, `VocabType`, `TokenAttr` and `RopeType` are typed Go constants with `String` methods, so callers see names instead of bare ints. Those values are hand-copied from the engine headers, which is a silent-breakage risk: if llama.cpp renumbers an enum, the Go names keep compiling and start decoding to the wrong thing.

So `binding.cpp` now `static_assert`s every mirrored value against the engine:

```cpp
static_assert(LLAMA_ROPE_TYPE_IMROPE == 40, "RopeImrope out of sync with llama.go");
```

An upstream renumbering becomes a **build failure in this repo** rather than a subtle wrong answer. (All 30 assertions pass at v0.3.0; the RoPE values were checked against `ggml.h`, not assumed.)

## Bounds checking

Every accessor checks its token against `n_vocab` before indexing, rather than trusting the caller. A test covers `-1`, `n_vocab` and `1<<30` for each.

## Engine APIs newly covered (20)

`llama_vocab_type`, `llama_vocab_get_text`, `llama_vocab_get_score`, `llama_vocab_get_attr`, `llama_vocab_is_eog`, `llama_vocab_is_control`, `llama_vocab_get_add_sep`, `llama_vocab_get_suppress_tokens`, `llama_model_rope_type`, `llama_model_ftype`, `llama_model_decoder_start_token`, `llama_model_n_embd_inp`, `llama_model_n_embd_out`, `llama_model_n_layer_nextn`, `llama_model_n_cls_out`, `llama_model_cls_label`, `llama_model_is_hybrid`, `llama_model_is_diffusion`, `llama_ftype_name`, `llama_flash_attn_type_name`