### PR TITLE
feat: session files and per-sequence state persistence

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -1628,3 +1628,130 @@ static_assert(LLAMA_ROPE_TYPE_NEOX   ==  2, "RopeNeox out of sync with llama.go"
 static_assert(LLAMA_ROPE_TYPE_MROPE  ==  8, "RopeMrope out of sync with llama.go");
 static_assert(LLAMA_ROPE_TYPE_VISION == 24, "RopeVision out of sync with llama.go");
 static_assert(LLAMA_ROPE_TYPE_IMROPE == 40, "RopeImrope out of sync with llama.go");
+
+//
+// State and session persistence
+//
+// The whole-context helpers (load_state / save_state) round-trip everything.
+// These add the two things they cannot express: a session file that carries
+// its own token list, and per-sequence state, which is what lets a server
+// checkpoint one conversation slot without disturbing the others.
+//
+
+long long state_get_size(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (long long) llama_state_get_size(state->ctx);
+}
+
+// Serializes the whole context into buf. Returns the number of bytes written,
+// or the negative of the required size when buf_size is too small.
+long long state_get_data(void* state_ptr, unsigned char* buf, long long buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const size_t need = llama_state_get_size(state->ctx);
+    if (buf_size < 0 || (size_t) buf_size < need) {
+        return -(long long) need;
+    }
+    return (long long) llama_state_get_data(state->ctx, buf, (size_t) buf_size);
+}
+
+// Restores a context previously serialized by state_get_data. Returns the
+// number of bytes consumed, or 0 on failure.
+long long state_set_data(void* state_ptr, const unsigned char* buf, long long buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (buf == nullptr || buf_size <= 0) {
+        return 0;
+    }
+    return (long long) llama_state_set_data(state->ctx, buf, (size_t) buf_size);
+}
+
+// Session files carry the prompt tokens alongside the context state, so a
+// process can resume a conversation it did not itself start.
+bool state_save_file(void* state_ptr, const char* path, const int* tokens, int n_tokens) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (n_tokens < 0) {
+        return false;
+    }
+    return llama_state_save_file(state->ctx, path, (const llama_token*) tokens, (size_t) n_tokens);
+}
+
+// Loads a session file into the context. Returns the number of tokens read,
+// or -1 on failure -- including when max_tokens is smaller than the file's
+// token count, which the engine rejects outright rather than truncating.
+int state_load_file(void* state_ptr, const char* path, int* tokens_out, int max_tokens) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (max_tokens < 0) {
+        return -1;
+    }
+    size_t n_out = 0;
+    if (!llama_state_load_file(state->ctx, path, (llama_token*) tokens_out,
+                               (size_t) max_tokens, &n_out)) {
+        return -1;
+    }
+    return (int) n_out;
+}
+
+long long state_seq_get_size(void* state_ptr, int seq_id) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (long long) llama_state_seq_get_size(state->ctx, seq_id);
+}
+
+// As state_get_data, but for a single sequence.
+long long state_seq_get_data(void* state_ptr, unsigned char* buf, long long buf_size, int seq_id) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const size_t need = llama_state_seq_get_size(state->ctx, seq_id);
+    if (buf_size < 0 || (size_t) buf_size < need) {
+        return -(long long) need;
+    }
+    return (long long) llama_state_seq_get_data(state->ctx, buf, (size_t) buf_size, seq_id);
+}
+
+// Restores a sequence into dest_seq_id, which need not be the id it was saved
+// from. Returns the number of bytes consumed, or 0 on failure.
+long long state_seq_set_data(void* state_ptr, const unsigned char* buf, long long buf_size, int dest_seq_id) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (buf == nullptr || buf_size <= 0) {
+        return 0;
+    }
+    return (long long) llama_state_seq_set_data(state->ctx, buf, (size_t) buf_size, dest_seq_id);
+}
+
+bool state_seq_save_file(void* state_ptr, const char* path, int seq_id, const int* tokens, int n_tokens) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (n_tokens < 0) {
+        return false;
+    }
+    return llama_state_seq_save_file(state->ctx, path, seq_id,
+                                     (const llama_token*) tokens, (size_t) n_tokens) > 0;
+}
+
+// Reports how many tokens a per-sequence state file holds, without loading any
+// state. Returns -1 if the file cannot be read. There is no equivalent probe
+// for whole-session files: llama_state_load_file has no such mode, so callers
+// must size that buffer from the context.
+int state_seq_file_token_count(void* state_ptr, const char* path) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    size_t n_out = 0;
+    if (llama_state_seq_load_file(state->ctx, path, 0, nullptr, 0, &n_out) == 0) {
+        return -1;
+    }
+    return (int) n_out;
+}
+
+// Loads a per-sequence file into dest_seq_id, which need not be the id it was
+// saved from. Returns the number of tokens read, or -1 on failure — including
+// when max_tokens is smaller than the file's token count, which the engine
+// treats as an error rather than a truncation. Size the buffer with
+// state_seq_file_token_count first.
+int state_seq_load_file(void* state_ptr, const char* path, int dest_seq_id,
+                        int* tokens_out, int max_tokens) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (tokens_out == nullptr || max_tokens < 0) {
+        return -1;
+    }
+    size_t n_out = 0;
+    if (llama_state_seq_load_file(state->ctx, path, dest_seq_id, (llama_token*) tokens_out,
+                                  (size_t) max_tokens, &n_out) == 0) {
+        return -1;
+    }
+    return (int) n_out;
+}

--- a/binding.h
+++ b/binding.h
@@ -94,6 +94,29 @@ bool memory_seq_rm(void* state_ptr, int seq_id, int p0, int p1);
 void memory_seq_cp(void* state_ptr, int src, int dst, int p0, int p1);
 void memory_seq_keep(void* state_ptr, int seq_id);
 
+
+// State and session persistence. The load_state / save_state pair above
+// round-trips a whole context as raw bytes. These add what it cannot express:
+// a session file that carries its own token list, and per-sequence state, so a
+// server can checkpoint one conversation slot without touching the others.
+//
+// The state_*_get_data functions return the bytes written, or the negative of
+// the required size when the buffer is too small. The file loaders return the
+// token count, or -1 on failure -- a buffer smaller than the file's token
+// count is a failure, not a truncation, so probe the size first.
+long long state_get_size(void* state_ptr);
+long long state_get_data(void* state_ptr, unsigned char* buf, long long buf_size);
+long long state_set_data(void* state_ptr, const unsigned char* buf, long long buf_size);
+bool state_save_file(void* state_ptr, const char* path, const int* tokens, int n_tokens);
+int state_load_file(void* state_ptr, const char* path, int* tokens_out, int max_tokens);
+long long state_seq_get_size(void* state_ptr, int seq_id);
+long long state_seq_get_data(void* state_ptr, unsigned char* buf, long long buf_size, int seq_id);
+long long state_seq_set_data(void* state_ptr, const unsigned char* buf, long long buf_size, int dest_seq_id);
+bool state_seq_save_file(void* state_ptr, const char* path, int seq_id, const int* tokens, int n_tokens);
+int state_seq_file_token_count(void* state_ptr, const char* path);
+int state_seq_load_file(void* state_ptr, const char* path, int dest_seq_id,
+                        int* tokens_out, int max_tokens);
+
 // Model info functions
 int get_model_n_vocab(void* state_ptr);
 int get_model_n_ctx_train(void* state_ptr);

--- a/llama.go
+++ b/llama.go
@@ -1134,6 +1134,172 @@ func SystemInfo() string {
 	return string(buf[:ret])
 }
 
+// StateSize returns the number of bytes StateData will produce for the whole
+// context, including every sequence in the KV cache.
+func (l *LLama) StateSize() int64 {
+	return int64(C.state_get_size(l.state))
+}
+
+// StateData serializes the entire context — KV cache, RNG, logits — into a
+// byte slice that SetStateData can restore into a context created with the
+// same model and the same geometry.
+//
+// It is the in-memory counterpart of SaveState. Prefer SequenceStateData when
+// you only need one conversation, since whole-context state grows with the
+// full KV cache.
+func (l *LLama) StateData() ([]byte, error) {
+	return stateBuf(func(buf []byte) int64 {
+		var p *C.uchar
+		if len(buf) > 0 {
+			p = (*C.uchar)(unsafe.Pointer(&buf[0]))
+		}
+		return int64(C.state_get_data(l.state, p, C.longlong(len(buf))))
+	})
+}
+
+// SetStateData restores a context previously serialized by StateData. The
+// context must have been created from the same model with the same geometry;
+// restoring mismatched state is not detected and will misbehave.
+func (l *LLama) SetStateData(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("llama: empty state data")
+	}
+	n := int64(C.state_set_data(l.state, (*C.uchar)(unsafe.Pointer(&data[0])), C.longlong(len(data))))
+	if n == 0 {
+		return errors.New("llama: failed to restore context state")
+	}
+	return nil
+}
+
+// SaveSessionFile writes the context state plus tokens to path, in llama.cpp's
+// session file format. Unlike SaveState the token list travels with the state,
+// so another process can resume a conversation it did not start.
+func (l *LLama) SaveSessionFile(path string, tokens []int32) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	var p *C.int
+	if len(tokens) > 0 {
+		p = (*C.int)(unsafe.Pointer(&tokens[0]))
+	}
+	if !bool(C.state_save_file(l.state, cPath, p, C.int(len(tokens)))) {
+		return fmt.Errorf("llama: failed to write session file %q", path)
+	}
+	return nil
+}
+
+// LoadSessionFile restores a session written by SaveSessionFile and returns
+// the tokens stored alongside it.
+//
+// The engine rejects a session whose token count exceeds the buffer rather
+// than truncating, so the buffer is sized from the context: a session can
+// never hold more tokens than the context it was captured from.
+func (l *LLama) LoadSessionFile(path string) ([]int32, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	capacity := int(C.context_n_ctx(l.state))
+	if capacity <= 0 {
+		capacity = l.contextSize
+	}
+	tokens := make([]int32, capacity)
+	n := int(C.state_load_file(l.state, cPath, (*C.int)(unsafe.Pointer(&tokens[0])), C.int(capacity)))
+	if n < 0 {
+		return nil, fmt.Errorf("llama: failed to read session file %q", path)
+	}
+	return tokens[:n], nil
+}
+
+// SequenceStateSize returns the number of bytes SequenceStateData will produce
+// for a single sequence.
+func (l *LLama) SequenceStateSize(seqID int32) int64 {
+	return int64(C.state_seq_get_size(l.state, C.int(seqID)))
+}
+
+// SequenceStateData serializes just the KV-cache state of one sequence. This
+// is the checkpoint a server wants: it captures a single conversation slot
+// without dragging along every other sequence in the context.
+func (l *LLama) SequenceStateData(seqID int32) ([]byte, error) {
+	return stateBuf(func(buf []byte) int64 {
+		var p *C.uchar
+		if len(buf) > 0 {
+			p = (*C.uchar)(unsafe.Pointer(&buf[0]))
+		}
+		return int64(C.state_seq_get_data(l.state, p, C.longlong(len(buf)), C.int(seqID)))
+	})
+}
+
+// SetSequenceStateData restores sequence state produced by SequenceStateData
+// into destSeqID, which need not be the sequence it was captured from — that
+// is what makes it usable for moving a conversation between context slots.
+func (l *LLama) SetSequenceStateData(data []byte, destSeqID int32) error {
+	if len(data) == 0 {
+		return errors.New("llama: empty sequence state data")
+	}
+	n := int64(C.state_seq_set_data(l.state, (*C.uchar)(unsafe.Pointer(&data[0])),
+		C.longlong(len(data)), C.int(destSeqID)))
+	if n == 0 {
+		return fmt.Errorf("llama: failed to restore state into sequence %d", destSeqID)
+	}
+	return nil
+}
+
+// SaveSequenceFile writes one sequence's state and its tokens to path.
+func (l *LLama) SaveSequenceFile(path string, seqID int32, tokens []int32) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	var p *C.int
+	if len(tokens) > 0 {
+		p = (*C.int)(unsafe.Pointer(&tokens[0]))
+	}
+	if !bool(C.state_seq_save_file(l.state, cPath, C.int(seqID), p, C.int(len(tokens)))) {
+		return fmt.Errorf("llama: failed to write sequence file %q", path)
+	}
+	return nil
+}
+
+// LoadSequenceFile restores a file written by SaveSequenceFile into destSeqID
+// and returns the tokens stored with it. The file's token count is probed
+// first, so the buffer is always exactly the right size.
+func (l *LLama) LoadSequenceFile(path string, destSeqID int32) ([]int32, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	n := int(C.state_seq_file_token_count(l.state, cPath))
+	if n < 0 {
+		return nil, fmt.Errorf("llama: failed to read sequence file %q", path)
+	}
+
+	// A zero-token file still carries state, so the load must happen either
+	// way; give the engine a non-nil pointer to write into regardless.
+	tokens := make([]int32, n+1)
+	got := int(C.state_seq_load_file(l.state, cPath, C.int(destSeqID),
+		(*C.int)(unsafe.Pointer(&tokens[0])), C.int(n)))
+	if got < 0 {
+		return nil, fmt.Errorf("llama: failed to load sequence file %q", path)
+	}
+	return tokens[:got], nil
+}
+
+// stateBuf runs fn against a buffer sized by fn's own report. fn returns the
+// bytes written, or the negative of the size it needs; the first call probes
+// with an empty buffer, so exactly one allocation of the right size happens.
+func stateBuf(fn func(buf []byte) int64) ([]byte, error) {
+	need := fn(nil)
+	if need == 0 {
+		return nil, errors.New("llama: state is empty")
+	}
+	if need < 0 {
+		need = -need
+	}
+	buf := make([]byte, need)
+	got := fn(buf)
+	if got <= 0 {
+		return nil, errors.New("llama: failed to serialize state")
+	}
+	return buf[:got], nil
+}
 func (l *LLama) LoadState(state string) error {
 	d := C.CString(state)
 	w := C.CString("rb")

--- a/llama_test.go
+++ b/llama_test.go
@@ -2,6 +2,7 @@ package llama_test
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/AshkanYarmoradi/go-llama.cpp"
@@ -628,6 +629,190 @@ how much is 2+2?
 			Expect(arch.EmbdInp).To(BeNumerically(">", 0))
 			Expect(arch.EmbdOut).To(BeNumerically(">", 0))
 			Expect(arch.FileTypeName).To(Equal(FileTypeName(arch.FileType)))
+		})
+	})
+
+	Context("State and session persistence", func() {
+		newModel := func() *LLama {
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(model).ToNot(BeNil())
+			return model
+		}
+
+		// decodeInto pushes tokens through the model on seqID and returns them.
+		decodeInto := func(model *LLama, text string, seqID int32) []int32 {
+			tokens := model.Tokenize(text, true, false)
+			Expect(tokens).ToNot(BeEmpty())
+			batch := NewBatch(len(tokens), 1)
+			defer batch.Free()
+			for i, tok := range tokens {
+				Expect(batch.Add(tok, int32(i), []int32{seqID}, i == len(tokens)-1)).To(Succeed())
+			}
+			Expect(model.Decode(batch)).To(Equal(0))
+			return tokens
+		}
+
+		// stepFrom decodes one more token at pos on seqID and returns the
+		// resulting logits. Restored state is checked with this rather than by
+		// comparing logits buffers directly: llama_context::state_write_data
+		// serializes the memory module and the architecture string, and
+		// nothing else, so the logits buffer is deliberately not part of a
+		// saved state. What must round-trip is the cache — and the way to show
+		// that is that the next token predicts identically.
+		stepFrom := func(model *LLama, tok int32, pos int32, seqID int32) []float32 {
+			batch := NewBatch(1, 1)
+			defer batch.Free()
+			Expect(batch.Add(tok, pos, []int32{seqID}, true)).To(Succeed())
+			Expect(model.Decode(batch)).To(Equal(0))
+			return append([]float32(nil), model.Logits(-1)...)
+		}
+
+		It("round-trips whole-context state in memory", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			tokens := decodeInto(model, "The capital of France is", 0)
+
+			data, err := model.StateData()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(int64(len(data))).To(BeNumerically("<=", model.StateSize()))
+
+			// What the model predicts one step past the captured state.
+			expected := stepFrom(model, tokens[0], int32(len(tokens)), 0)
+			Expect(expected).ToNot(BeEmpty())
+
+			// Disturb the context. The cache is cleared first because
+			// decodeInto always starts at position 0, and decoding into a
+			// sequence that still holds tokens collides on position.
+			model.MemoryClear(true)
+			decodeInto(model, "Something else entirely", 0)
+
+			Expect(model.SetStateData(data)).To(Succeed())
+			Expect(model.MemorySeqPosMax(0)).To(Equal(int32(len(tokens)-1)), "cache did not come back")
+
+			// Same step from the restored cache must predict the same thing.
+			Expect(stepFrom(model, tokens[0], int32(len(tokens)), 0)).To(Equal(expected))
+		})
+
+		It("rejects empty state data", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			Expect(model.SetStateData(nil)).To(HaveOccurred())
+			Expect(model.SetSequenceStateData(nil, 0)).To(HaveOccurred())
+		})
+
+		It("round-trips a session file with its token list", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			tokens := decodeInto(model, "The capital of France is", 0)
+			expected := stepFrom(model, tokens[0], int32(len(tokens)), 0)
+
+			// Capture after the extra step so the file holds that cache state.
+			path := filepath.Join(GinkgoT().TempDir(), "session.bin")
+			Expect(model.SaveSessionFile(path, tokens)).To(Succeed())
+
+			model.MemoryClear(true)
+			got, err := model.LoadSessionFile(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).To(Equal(tokens))
+			Expect(model.MemorySeqPosMax(0)).To(Equal(int32(len(tokens))))
+
+			// The saved cache already includes the extra step, so redoing it
+			// would collide; drop it first, then repeat and compare.
+			Expect(model.MemorySeqRemove(0, int32(len(tokens)), -1)).To(BeTrue())
+			Expect(stepFrom(model, tokens[0], int32(len(tokens)), 0)).To(Equal(expected))
+		})
+
+		It("round-trips one sequence without disturbing the others", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model, err := New(testModelPath, EnableF16Memory, SetContext(256), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			if model.ContextParams().NSeqMax < 2 {
+				Skip("context holds a single sequence")
+			}
+
+			a := decodeInto(model, "The capital of France is", 0)
+			decodeInto(model, "The largest ocean is", 1)
+
+			Expect(model.SequenceStateSize(0)).To(BeNumerically(">", int64(0)))
+			data, err := model.SequenceStateData(0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).ToNot(BeEmpty())
+
+			posMax1 := model.MemorySeqPosMax(1)
+
+			// Drop sequence 0 only, then restore it from the checkpoint.
+			Expect(model.MemorySeqRemove(0, -1, -1)).To(BeTrue())
+			Expect(model.MemorySeqPosMax(0)).To(Equal(int32(-1)))
+
+			Expect(model.SetSequenceStateData(data, 0)).To(Succeed())
+			Expect(model.MemorySeqPosMax(0)).To(Equal(int32(len(a) - 1)))
+
+			// Sequence 1 was never touched.
+			Expect(model.MemorySeqPosMax(1)).To(Equal(posMax1))
+		})
+
+		It("restores a sequence file into a different sequence id", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model, err := New(testModelPath, EnableF16Memory, SetContext(256), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			if model.ContextParams().NSeqMax < 2 {
+				Skip("context holds a single sequence")
+			}
+
+			tokens := decodeInto(model, "The capital of France is", 0)
+
+			path := filepath.Join(GinkgoT().TempDir(), "seq.bin")
+			Expect(model.SaveSequenceFile(path, 0, tokens)).To(Succeed())
+
+			model.MemoryClear(true)
+
+			// Saved from sequence 0, restored into sequence 1.
+			got, err := model.LoadSequenceFile(path, 1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).To(Equal(tokens))
+			Expect(model.MemorySeqPosMax(1)).To(Equal(int32(len(tokens) - 1)))
+			Expect(model.MemorySeqPosMax(0)).To(Equal(int32(-1)))
+		})
+
+		It("reports an error for a missing or malformed file", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			dir := GinkgoT().TempDir()
+			_, err := model.LoadSessionFile(filepath.Join(dir, "does-not-exist.bin"))
+			Expect(err).To(HaveOccurred())
+
+			_, err = model.LoadSequenceFile(filepath.Join(dir, "does-not-exist.bin"), 0)
+			Expect(err).To(HaveOccurred())
+
+			junk := filepath.Join(dir, "junk.bin")
+			Expect(os.WriteFile(junk, []byte("not a state file at all"), 0o600)).To(Succeed())
+			_, err = model.LoadSequenceFile(junk, 0)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
Stacked on #209 -> #208 -> #207 -> #206.

The binding could serialize a whole context to a file (`load_state` / `save_state`) and nothing else. Two capabilities were missing, and they are the two a server actually needs.

## Per-sequence state — the real gap

Whole-context state grows with the entire KV cache, so checkpointing one conversation meant serializing every other sequence along with it. Now a single slot can be captured and restored on its own:

```go
data, _ := model.SequenceStateData(0)   // just sequence 0
model.SetSequenceStateData(data, 1)     // restore into a different slot
```

The destination id need not be the source id, which is what makes this usable for migrating a conversation between context slots. File variants (`SaveSequenceFile` / `LoadSequenceFile`) are there too.

The test proves the isolation property directly: decode into sequences 0 and 1, checkpoint 0, drop 0, restore it — and assert sequence 1's positions are untouched.

## Session files

llama.cpp's session format stores the prompt tokens alongside the context state, so a process can resume a conversation it did not itself start:

```go
model.SaveSessionFile(path, tokens)
tokens, err := model.LoadSessionFile(path)
```

Plus in-memory `StateData` / `SetStateData` for the whole context, which previously could only go through a file.

## Buffer contracts follow the engine

Rather than guessing sizes, each path uses what the engine actually promises — which I checked in `llama-context.cpp` instead of inferring from the header comments:

- `_get_data` reports the size it needs, so `stateBuf` probes with a nil buffer and allocates exactly once.
- The file loaders return **-1, not a short read**, when the buffer is too small — `llama_state_load_file` rejects an over-capacity token count outright rather than truncating.
- `LoadSequenceFile` probes the token count first. `llama_state_seq_load_file` supports a `NULL` `tokens_out` query, and on success it returns a **non-zero file offset**, not zero — my first pass had this backwards and would have treated every successful probe as a failure.
- `LoadSessionFile` has no such probe available, so it sizes from `n_ctx`, a hard upper bound on what a session can contain.

## Engine APIs newly covered (10)

`llama_state_get_size`, `llama_state_get_data`, `llama_state_set_data`, `llama_state_save_file`, `llama_state_load_file`, `llama_state_seq_get_size`, `llama_state_seq_get_data`, `llama_state_seq_set_data`, `llama_state_seq_save_file`, `llama_state_seq_load_file`

## Verification

Six tests: whole-context round-trip asserting the restored logits are bit-identical, session-file round-trip, per-sequence isolation, cross-sequence-id restore, empty-input rejection, and missing/malformed file handling.