### PR TITLE
ci: fix branch trigger, add fast lint gate, make GPU tests opt-in

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,37 @@
 version: 2
 
 updates:
+  # The llama.cpp engine. Daily, because upstream moves fast and a bump that
+  # breaks the binding should surface within a day rather than a month's worth
+  # of commits later.
   - package-ecosystem: gitsubmodule
-    schedule:
-        interval: "daily"
     directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: build
+
+  # Go dependencies (the test toolchain: Ginkgo, Gomega).
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+    groups:
+      go-test-deps:
+        patterns:
+          - "github.com/onsi/*"
+
+  # GitHub Actions. Workflows pin actions by commit SHA, so without this they
+  # would never be updated at all.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,81 @@
+name: Lint
+
+# Fast static checks. The CI workflow downloads a multi-gigabyte model and
+# builds all of llama.cpp, so it takes ~20 minutes per job; these run in about
+# a minute and catch the mistakes that do not need any of that.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  workflow_dispatch:
+
+concurrency:
+  group: lint-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+          cache: true
+
+      # Scoped to this repo's own sources: the llama.cpp submodule is not ours
+      # to format.
+      - name: gofmt
+        run: |
+          unformatted="$(find . -name '*.go' -not -path './llama.cpp/*' -print0 | xargs -0 gofmt -l -e)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::these files are not gofmt-clean:"
+            echo "$unformatted"
+            gofmt -d -e $unformatted
+            exit 1
+          fi
+
+      # go vet type-checks the cgo layer against binding.h without needing
+      # libbinding.a, so it catches signature drift between Go and C.
+      - name: go vet
+        run: go vet ./...
+
+      - name: go mod tidy is up to date
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+  cpp:
+    name: C++
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+
+      # Compiles binding.cpp against the llama.cpp headers with the same
+      # warning flags the real build uses. Needs no CMake and no llama.cpp
+      # build, so it reports engine API breakage in seconds rather than after
+      # a full compile.
+      - name: Compile-check binding.cpp
+        run: |
+          c++ -I./llama.cpp -I./llama.cpp/include -I./llama.cpp/ggml/include \
+              -I. -I./llama.cpp/common \
+              -std=c++17 -fPIC -Wall -Wextra -Wpedantic -Wcast-qual \
+              -Wno-unused-function -fsyntax-only binding.cpp
+
+      - name: Every binding.h declaration is defined
+        run: bash ./scripts/check-binding-symbols.sh

--- a/.github/workflows/test-gpu.yaml
+++ b/.github/workflows/test-gpu.yaml
@@ -1,31 +1,47 @@
 ---
 name: 'GPU tests'
 
+# This job needs a self-hosted CUDA runner. When none is attached, an
+# unconditional `pull_request` trigger leaves a queued check on every PR that
+# sits there until GitHub cancels it 24 hours later — which is what had been
+# happening on every PR since August.
+#
+# So it is opt-in: run it by hand from the Actions tab, or put the `gpu` label
+# on a PR that needs it. Pushes to main and tags still run it, and the job
+# times out rather than parking a runner for a day.
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
-      - master
+      - main
     tags:
       - '*'
+  workflow_dispatch:
 
 concurrency:
   group: ci-gpu-tests-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu-latest:
+    # On a PR, only when explicitly labelled `gpu`.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'gpu')
     runs-on: self-hosted
+    timeout-minutes: 90
     strategy:
       matrix:
-        go-version: ['1.24.x']
+        go-version: ['1.25.x']
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           submodules: true
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
       # You can test your matrix by printing the current Go version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,20 +1,36 @@
 name: CI
+
+# The matrix tracks the `go` directive in go.mod. Testing an older toolchain
+# than the module declares does not work: setup-go pins GOTOOLCHAIN=local, so
+# the build fails outright rather than quietly fetching a newer Go and testing
+# that instead.
 on:
   pull_request:
   push:
     branches:
-      - master
+      - main
     tags:
       - '*'
+  workflow_dispatch:
+
+# Each job here downloads a multi-gigabyte model and builds all of llama.cpp,
+# so a superseded run has nothing left to prove.
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   ubuntu-latest:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.24.x', 'stable']
+        go-version: ['1.25.x', 'stable']
     steps:
       - name: Clone
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           submodules: true
       - name: Dependencies
@@ -22,7 +38,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install build-essential
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
       # You can test your matrix by printing the current Go version
@@ -36,14 +52,14 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        go-version: ['1.24.x', 'stable']
+        go-version: ['1.25.x', 'stable']
     steps:
       - name: Clone
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           submodules: true
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
       # You can test your matrix by printing the current Go version
@@ -57,14 +73,14 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        go-version: ['1.24.x', 'stable']
+        go-version: ['1.25.x', 'stable']
     steps:
       - name: Clone
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: 
           submodules: true
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
       # You can test your matrix by printing the current Go version

--- a/scripts/check-binding-symbols.sh
+++ b/scripts/check-binding-symbols.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Verify that every function declared in binding.h is actually defined in
+# binding.cpp.
+#
+# cgo compiles binding.h into the Go package, so a declaration with no
+# definition type-checks fine and only fails much later, at link time, inside a
+# full `make test` that first builds all of llama.cpp. This check reproduces the
+# same failure in a couple of seconds using only the llama.cpp headers.
+#
+# It compiles binding.cpp to an object file and asks the toolchain which symbols
+# it defines, rather than pattern-matching definitions -- so it agrees with the
+# linker by construction.
+#
+# Usage: scripts/check-binding-symbols.sh
+# Exits non-zero and lists the offending names if any declaration is unbacked.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ ! -f llama.cpp/include/llama.h ]; then
+    echo "error: llama.cpp submodule is not checked out." >&2
+    echo "       run: git submodule update --init --recursive" >&2
+    exit 1
+fi
+
+CXX="${CXX:-c++}"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+obj="$workdir/binding.o"
+
+"$CXX" \
+    -I./llama.cpp -I./llama.cpp/include -I./llama.cpp/ggml/include \
+    -I. -I./llama.cpp/common \
+    -std=c++17 -fPIC -O0 \
+    -c binding.cpp -o "$obj"
+
+# Symbols binding.o defines. The binding is extern "C", so these are plain
+# unmangled names.
+"$(command -v nm)" -g --defined-only "$obj" \
+    | awk '$2 ~ /^[TtWwDd]$/ { print $3 }' \
+    | sed 's/^_//' \
+    | sort -u > "$workdir/defined.txt"
+
+# Function names declared in binding.h.
+#
+# Only the extern "C" block counts: that is the ABI surface cgo links against.
+# The C++-linkage helpers below it (create_vector, delete_vector) are name
+# mangled and internal to binding.cpp, so they are out of scope here.
+#
+# Declarations marked `extern` are also skipped -- those are cgo exports such as
+# tokenCallback, which Go defines and C only calls.
+#
+# Strip comments, then split on ';' so each declaration is one record however it
+# wraps across lines, and take the identifier before the parameter list.
+awk '/extern "C" \{/ { inblock = 1; next } inblock && /^\}$/ { exit } inblock' binding.h \
+    | sed -e 's://.*::' \
+    | tr '\n' ' ' \
+    | tr ';' '\n' \
+    | grep -v '\bextern\b' \
+    | grep -oE '\b[a-zA-Z_][a-zA-Z_0-9]*[[:space:]]*\(' \
+    | tr -d ' (' \
+    | grep -vxE 'if|for|while|switch|return|sizeof' \
+    | sort -u > "$workdir/declared.txt"
+
+if [ ! -s "$workdir/declared.txt" ]; then
+    echo "error: found no declarations in binding.h -- has its structure changed?" >&2
+    exit 1
+fi
+
+missing="$(comm -23 "$workdir/declared.txt" "$workdir/defined.txt" || true)"
+
+if [ -n "$missing" ]; then
+    echo "error: declared in binding.h but not defined in binding.cpp:" >&2
+    echo "$missing" | sed 's/^/  /' >&2
+    echo >&2
+    echo "This would fail at link time when cgo builds the package." >&2
+    exit 1
+fi
+
+echo "ok: all $(wc -l < "$workdir/declared.txt" | tr -d ' ') declarations in binding.h are defined in binding.cpp"


### PR DESCRIPTION
Stacked on #210 -> #209 -> #208 -> #207 -> #206.

Four CI problems, all found while pushing the v0.3.0 build fix through.

## 1. CI has never run on the default branch

Both workflows trigger on:

```yaml
push:
  branches:
    - master
```

This repo's default branch is `main`. That trigger has never matched — the entire workflow history is `pull_request` runs. Nothing has validated a merge commit.

## 2. The GPU workflow left a hung check on every PR

`runs-on: self-hosted` with an unconditional `pull_request` trigger, and no self-hosted runner is attached. Every PR since at least August queued a GPU job that sat there until GitHub killed it 24 hours later. #205 shows one at `24h0m10s`.

Now opt-in: `workflow_dispatch`, or the `gpu` label on a PR. Pushes to main and tags still run it, so nothing is lost if a runner comes back — plus `timeout-minutes: 90` so it can never park a runner for a day again.

## 3. A one-line mistake cost 20 minutes to find out about

Every existing job downloads a multi-gigabyte model and builds all of llama.cpp before it can tell you a file isn't gofmt-clean.

The new **Lint** workflow does everything that needs none of that, in about a minute:

- `gofmt` (scoped to our sources, not the submodule)
- `go vet` — type-checks the entire cgo layer against `binding.h` without needing `libbinding.a`, so it catches Go/C signature drift
- `go mod tidy` freshness
- `-fsyntax-only` compile of `binding.cpp` with the real warning flags — **this is what catches an upstream API break like #205's**

## 4. Declared-but-undefined C functions were invisible until link time

cgo compiles `binding.h` into the package, so a declaration with no definition type-checks fine and only fails inside a full `make test`.

`scripts/check-binding-symbols.sh` compiles `binding.cpp` to an object file and diffs `nm --defined-only` against the declarations in `binding.h`'s `extern "C"` block. It agrees with the linker *by construction* rather than by pattern-matching definitions, and correctly excludes the two categories that legitimately aren't there: `extern` cgo exports defined in Go (`tokenCallback`) and the C++-linkage helpers below the block.

**I hit this exact bug earlier in this branch stack.** A `sed` range in the chat-template work deleted a block of definitions while `binding.h` kept declaring them; `go vet` and `-fsyntax-only` both passed, and it would only have surfaced as a link error 20 minutes into CI. I caught it by hand and fixed the affected branches — this script makes that class of error impossible to miss again. It is verified in both directions (passes clean, and fails on an injected unbacked declaration).

## Also

- Actions pinned by SHA in **both** workflows (`checkout` was pinned in one and floating `@v4` in the other), on versions that don't trigger the Node 20 deprecation warning.
- `concurrency` groups so a superseded push stops burning a 20-minute job.
- `permissions: contents: read` on every workflow.
- Dependabot watched only `gitsubmodule`; it now covers `gomod` and `github-actions` too. The latter matters specifically because the workflows pin by SHA — without it, those pins would never be updated.