### PR TITLE
docs: package documentation, accurate README, contributor guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Something in the binding behaves incorrectly
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, please check whether the problem reproduces with
+        llama.cpp itself (`llama-cli` from the submodule). If it does, it
+        belongs in [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp/issues)
+        rather than here — this repository is the Go binding layer.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you expected, and what you got instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproducer
+      description: >
+        The smallest Go program that shows the problem, plus the command you
+        built and ran it with.
+      render: go
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: go-llama.cpp commit
+      description: "`git rev-parse HEAD`"
+    validations:
+      required: true
+
+  - type: input
+    id: submodule
+    attributes:
+      label: llama.cpp submodule commit
+      description: "`git -C llama.cpp rev-parse HEAD`"
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: Name and quantization, e.g. "Llama-3.1-8B-Instruct Q4_K_M".
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Build type
+      options:
+        - CPU (default)
+        - cublas (NVIDIA)
+        - hipblas (AMD)
+        - metal (Apple)
+        - clblas (OpenCL)
+        - openblas
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS and version, Go version (`go version`), compiler version.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Output
+      description: >
+        Relevant compiler errors or runtime output. llama.cpp is verbose on
+        stderr; include it, it usually says what went wrong.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/engine_api_gap.yml
+++ b/.github/ISSUE_TEMPLATE/engine_api_gap.yml
@@ -1,0 +1,36 @@
+name: Missing llama.cpp API
+description: A function in llama.h that the Go binding does not expose
+labels: [enhancement, engine-parity]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This binding aims to cover llama.cpp's C API. Functions upstream marks
+        `DEPRECATED` are deliberately left out — if you need one of those, the
+        request is for whatever replaced it.
+
+  - type: input
+    id: symbol
+    attributes:
+      label: Engine function
+      description: The `llama_*` name as it appears in `llama.cpp/include/llama.h`.
+      placeholder: llama_sampler_init_infill
+    validations:
+      required: true
+
+  - type: textarea
+    id: usecase
+    attributes:
+      label: What you would do with it
+      description: >
+        What you are trying to build. This decides the shape of the Go API —
+        the binding does not mirror C signatures one-to-one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: shape
+    attributes:
+      label: Suggested Go API
+      description: Optional. What the call would look like from Go.
+      render: go

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+<!--
+Thanks for contributing. Keep one concern per PR — it makes review and
+bisection much easier.
+-->
+
+## What this changes
+
+<!-- What the change does, and why it has to work this way. -->
+
+## Engine APIs newly covered
+
+<!--
+If this wraps llama.cpp functions that had no Go surface, list them:
+
+  llama_sampler_init_infill, llama_sampler_name
+
+Delete this section if it does not apply.
+-->
+
+## Breaking changes
+
+<!--
+Any change to an exported Go signature. Show before and after, and say what
+forced it — an upstream API change is a good reason, tidiness is not.
+
+Delete this section if there are none.
+-->
+
+## Checks
+
+- [ ] `gofmt -l -e .` is clean
+- [ ] `go vet ./...` passes
+- [ ] `./scripts/check-binding-symbols.sh` passes
+- [ ] `binding.cpp` compiles with the CI warning flags (see CONTRIBUTING.md)
+- [ ] Tested against a real model with `TEST_MODEL` set, or explained below why not
+- [ ] New tests live in their own `Context` block
+- [ ] Exported Go identifiers have doc comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+Notable changes to the Go API. The vendored llama.cpp submodule is bumped
+daily by Dependabot and those bumps are not listed individually — only the ones
+that changed this binding's behaviour.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- **Chat template application.** `ApplyChatTemplate` renders a `[]ChatMessage`
+  into a prompt using the model's own GGUF template, or a named one from
+  `BuiltinChatTemplates()`. Returns `ErrNoChatTemplate` when llama.cpp cannot
+  place the template, rather than emitting a malformed prompt.
+- **Per-sequence state persistence.** `SequenceStateData` /
+  `SetSequenceStateData` checkpoint a single conversation slot without
+  serializing the rest of the KV cache, and restore into any sequence id.
+  File variants: `SaveSequenceFile` / `LoadSequenceFile`.
+- **Session files.** `SaveSessionFile` / `LoadSessionFile` store the prompt
+  tokens alongside the context state. In-memory whole-context state is now
+  reachable too, via `StateData` / `SetStateData`.
+- **Context introspection and control.** `ContextParams()` reports the geometry
+  the context actually runs with — the engine clamps and rounds what it was
+  asked for. Plus `Threads` / `SetThreads`, `SetEmbeddings`, `SetCausalAttn`
+  and `Synchronize`.
+- **KV-cache completion.** `MemorySeqAdd`, `MemorySeqDiv`, `MemorySeqPosMin`,
+  `MemorySeqPosMax` and `MemoryCanShift`. Together with `MemorySeqRemove`
+  these make context shifting expressible.
+- **Performance counters.** `Perf()` / `PerfReset()` on both the context and a
+  sampler chain, replacing stderr scraping.
+- **Vocabulary introspection.** `VocabType`, `TokenText`, `TokenScore`,
+  `TokenAttr`, `IsEOG`, `IsControlToken`, `AddSeparator`, `SuppressTokens`.
+  `IsEOG` is the correct stop condition for a generation loop: many models
+  define several end-of-turn tokens, and comparing against `EOS` alone misses
+  them.
+- **Model architecture queries.** `Architecture()` reports RoPE type, file
+  type, encoder/decoder presence, recurrent/hybrid/diffusion flags, embedding
+  widths and classifier labels.
+- **Package-level helpers.** `Version()`, `TimeUS()`, `FileTypeName()`,
+  `FlashAttnTypeName()`.
+- Package documentation (`doc.go`), `CONTRIBUTING.md`, `SECURITY.md` and this
+  changelog.
+- `scripts/check-binding-symbols.sh`, which fails the build if `binding.h`
+  declares a function `binding.cpp` does not define — previously a link-time
+  error that only surfaced twenty minutes into CI.
+
+### Changed
+
+- **Breaking:** `SamplerPenalties` is now a method on `*LLama` rather than a
+  package function. llama.cpp v0.3.0 added a required `n_vocab` parameter to
+  `llama_sampler_init_penalties`, and the backend asserts it is non-zero, so
+  the stage cannot be built without the model. This matches `SamplerGrammar`
+  and `SamplerDRY`, which were already methods for the same reason.
+
+      llama.SamplerPenalties(...)   ->   model.SamplerPenalties(...)
+
+- Enum values mirrored into Go (`PoolingType`, `VocabType`, `TokenAttr`,
+  `RopeType`) are now guarded by `static_assert`s against the engine headers,
+  so an upstream renumbering becomes a build failure here instead of a silent
+  misdecode.
+- CI: the `push` trigger targeted `master`, which has never matched this
+  repo's `main` branch, so no merge has ever been validated. GPU tests are now
+  opt-in (`workflow_dispatch` or the `gpu` label) instead of leaving a queued
+  check on every PR for 24 hours. A new Lint workflow runs gofmt, vet and a
+  `binding.cpp` compile check in about a minute.
+
+### Fixed
+
+- **Build against llama.cpp v0.3.0.** `llama_sampler_init_penalties` gained a
+  leading `n_vocab` parameter and `llama_sampler_init_dry` dropped
+  `n_ctx_train`. Both are called from the binding, so the submodule bump broke
+  the build.
+- **`GetChatTemplate` silently truncated.** It used a fixed 4 KiB buffer and
+  returned however much fit. Most instruct models have templates larger than
+  that, so callers received a quietly cut-off template. Both layers now report
+  the length the value needs and the Go side grows to it.
+- `apply_chat_template` was a stub that ignored every argument and returned
+  `-1`; see Added above.
+
+## Earlier
+
+Before this changelog, changes were tracked only in the commit history. Notable
+entries:
+
+- `feat: composable sampler objects` (#184)
+- `feat: low-level batching, decode/encode, and KV-cache control` (#183)
+- `feat: multi-LoRA adapters via ApplyLoRA / ClearLoRA` (#182)
+- `fix: apply the parsed logit_bias in the sampler chain` (#181)
+- `feat: bounds-safe tokenize / detokenize / token-to-piece` (#180)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing
+
+Thanks for helping keep these bindings current with llama.cpp.
+
+## Getting set up
+
+```bash
+git clone --recurse-submodules https://github.com/AshkanYarmoradi/go-llama.cpp
+cd go-llama.cpp
+make libbinding.a
+```
+
+`make libbinding.a` builds the vendored llama.cpp and links it into a static
+library. It takes a while the first time. Everything after that builds against
+it:
+
+```bash
+LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go build ./...
+```
+
+## The layers
+
+A change usually touches three files, in this order:
+
+| File | What lives there |
+|---|---|
+| `binding.cpp` | C++ that calls llama.cpp and hides its types behind `void*` |
+| `binding.h` | the `extern "C"` surface cgo sees |
+| `llama.go` | the Go API, with the doc comments users actually read |
+
+`llama.go` should read like Go, not like a C header. Return `[]int32` rather
+than a pointer and a length, `error` rather than a status code, and a typed
+enum with a `String` method rather than a bare int.
+
+### Buffer conventions
+
+C functions that fill a caller's buffer follow one of two contracts, and the
+header says which:
+
+- **snprintf semantics** for strings: return the length the value *needs*. A
+  return `>= buf_size` means it was truncated, and the caller retries at that
+  size. `get_model_chat_template` works this way.
+- **negative-required-size** for arrays: return the count written, or the
+  negative of the count needed. `tokenize_text` works this way.
+
+Pick whichever matches the underlying llama.cpp function and say so in the
+comment. Do not silently truncate — that was a real bug in `GetChatTemplate`,
+where models with a template over 4 KiB got a quietly cut-off result.
+
+### C++ exceptions must not reach cgo
+
+An exception that escapes into cgo calls `std::terminate`: the process dies
+with `SIGABRT` and no Go error is ever returned. Wrap anything that can throw.
+
+Things that throw, and have:
+
+- `llama_load_mode_from_str` throws `std::invalid_argument` for a name it does
+  not recognise.
+- `std::stoi` / `std::stof` throw on malformed input — which is any option
+  string that came from a caller.
+- Most llama.cpp file operations throw internally, though the `LLAMA_API`
+  entry points for state and quantization catch their own. Check before
+  relying on it.
+
+The pattern is to catch, report on stderr, and return the value the Go layer
+already treats as "not available":
+
+```cpp
+try {
+    return (int) llama_load_mode_from_str(str);
+} catch (const std::exception & e) {
+    fprintf(stderr, "%s: %s\n", __func__, e.what());
+    return -1;
+}
+```
+
+Neither `go vet` nor the compile check catches this — only a test that feeds in
+a bad value does. Write that test.
+
+### Mirrored enums
+
+Enum values copied into `llama.go` as Go constants must be backed by a
+`static_assert` in `binding.cpp`. If llama.cpp renumbers an enum, that turns a
+silent wrong answer into a build failure. See the block at the bottom of
+`binding.cpp`.
+
+## Testing
+
+Tests are [Ginkgo](https://onsi.github.io/ginkgo/) specs in `llama_test.go`.
+Most need a real model and skip without one:
+
+```bash
+export TEST_MODEL=/path/to/model.gguf
+LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go test -v ./...
+```
+
+`make test` will download a CodeLlama-7B Q2_K model and run against it, which
+is what CI does. That is several gigabytes — point `TEST_MODEL` at a model you
+already have if you can.
+
+Put new specs in their own `Context` block rather than adding `It`s inside an
+existing one. Sibling PRs conflict much less that way.
+
+Cover the edges, not just the happy path: out-of-range tokens, buffers a byte
+too small, empty inputs, and a model that lacks the feature.
+
+## Before you push
+
+These are the same checks CI runs, and they take seconds:
+
+```bash
+gofmt -l -e .
+go vet ./...
+./scripts/check-binding-symbols.sh
+```
+
+Plus the C++ compile check, which reproduces CI's `binding.o` step without
+building llama.cpp — this is what catches an upstream API break:
+
+```bash
+c++ -I./llama.cpp -I./llama.cpp/include -I./llama.cpp/ggml/include \
+    -I. -I./llama.cpp/common \
+    -std=c++17 -fPIC -Wall -Wextra -Wpedantic -Wcast-qual \
+    -Wno-unused-function -fsyntax-only binding.cpp
+```
+
+`check-binding-symbols.sh` exists because cgo compiles `binding.h` into the
+package: a function declared there but never defined type-checks fine and only
+fails at link time, twenty minutes into a full CI run.
+
+## When llama.cpp breaks the build
+
+Dependabot bumps the submodule daily, so upstream API changes show up as a red
+Dependabot PR. To fix one:
+
+1. Read the compiler error — it usually names the changed signature directly.
+2. Confirm against the header at that commit:
+   `gh api repos/ggml-org/llama.cpp/contents/include/llama.h?ref=<sha>`
+3. Check how llama.cpp's own `common/sampling.cpp` calls it. Matching upstream
+   is nearly always right.
+4. If the change forces a breaking Go API change, take it and explain why in
+   the commit message. The engine's contract wins.
+
+## Commit messages
+
+Conventional prefixes: `feat:`, `fix:`, `ci:`, `docs:`, `build:`, `refactor:`.
+
+Write the body for someone reading `git log` in a year. Say what changed, and
+why it had to change that way — especially when a signature moved because
+upstream forced it.
+
+## Pull requests
+
+One concern per PR. The history here is one feature per PR (see #180–#184), and
+it makes both review and bisection tractable.
+
+If your PR closes engine API gaps, list the `llama_*` functions it newly covers
+in the description. That is how the coverage story stays legible.

--- a/README.md
+++ b/README.md
@@ -4,118 +4,85 @@
 
 # 🦙 go-llama.cpp
 
-### *Blazing Fast LLM Inference in Go*
+### *Go bindings for llama.cpp — actively maintained*
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/AshkanYarmoradi/go-llama.cpp.svg)](https://pkg.go.dev/github.com/AshkanYarmoradi/go-llama.cpp)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/AshkanYarmoradi/go-llama.cpp/actions/workflows/test.yaml/badge.svg)](https://github.com/AshkanYarmoradi/go-llama.cpp/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/AshkanYarmoradi/go-llama.cpp)](https://goreportcard.com/report/github.com/AshkanYarmoradi/go-llama.cpp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**High-performance [llama.cpp](https://github.com/ggerganov/llama.cpp) bindings for Go — run LLMs locally with the power of C++ and the simplicity of Go.**
+**Run GGUF models locally from Go, on top of [llama.cpp](https://github.com/ggerganov/llama.cpp).**
 
-[Getting Started](#-quick-start) •
-[Features](#-features) •
-[API Reference](#-api-reference) •
-[GPU Acceleration](#-acceleration) •
-[Examples](#-examples)
+[Quick start](#quick-start) •
+[Generating text](#generating-text) •
+[Driving inference yourself](#driving-inference-yourself) •
+[GPU backends](#gpu-backends) •
+[API reference](#api-reference)
 
 </div>
 
 ---
 
-## 🌟 About This Fork
+## About this fork
 
-> **Note**: The original `go-skynet/go-llama.cpp` repository was unmaintained for over a year. As the llama.cpp ecosystem evolved rapidly with new features, samplers, and breaking API changes, the Go bindings fell behind.
->
-> **I decided to fork and actively maintain this project** to ensure the Go community has access to the latest llama.cpp capabilities. This fork is fully updated to support the modern llama.cpp API including the new sampler chain architecture and GGUF format.
+`go-skynet/go-llama.cpp` went unmaintained for over a year while llama.cpp
+changed underneath it — a new sampler architecture, the GGUF format, and
+several rounds of breaking API changes. This fork tracks upstream: a Dependabot
+job bumps the llama.cpp submodule daily, and the binding is updated to match
+when the engine's API moves.
 
-### What's New in This Fork
-
-- ✅ **Updated to latest llama.cpp** — Full compatibility with modern GGUF models
-- ✅ **New Sampler Chain API** — Modern sampling architecture with composable samplers
-- ✅ **XTC Sampler** — Cross-Token Coherence for improved generation quality
-- ✅ **DRY Sampler** — "Don't Repeat Yourself" penalty to reduce repetition
-- ✅ **TopNSigma Sampler** — Statistical sampling for better token selection
-- ✅ **Model Info API** — Query model metadata (vocab size, layers, parameters, etc.)
-- ✅ **Chat Templates** — Native support for model chat templates
-- ✅ **Fixed Build System** — Proper static linking with all CPU optimizations
-- ✅ ................
----
-
-## 🚀 Features
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  🎯 Performance First                                           │
-│  ────────────────────                                           │
-│  • Zero-copy data passing to C++                                │
-│  • Minimal CGO overhead                                         │
-│  • Native CPU optimizations (AVX, AVX2, AVX-512)               │
-├─────────────────────────────────────────────────────────────────┤
-│  🔧 Flexible Sampling                                           │
-│  ────────────────────                                           │
-│  • Temperature, Top-K, Top-P, Min-P                            │
-│  • Repetition & Presence Penalties                              │
-│  • XTC, DRY, TopNSigma (NEW!)                                  │
-│  • Mirostat v1 & v2                                            │
-├─────────────────────────────────────────────────────────────────┤
-│  ⚡ GPU Acceleration                                            │
-│  ────────────────────                                           │
-│  • NVIDIA CUDA / cuBLAS                                        │
-│  • AMD ROCm / HIPBlas                                          │
-│  • Apple Metal (M1/M2/M3)                                      │
-│  • OpenCL / CLBlast                                            │
-├─────────────────────────────────────────────────────────────────┤
-│  📦 Model Support                                               │
-│  ────────────────────                                           │
-│  • All GGUF quantization formats                               │
-│  • LLaMA, Mistral, Qwen, Phi, and 100+ architectures          │
-│  • LoRA adapter loading                                        │
-│  • Embeddings generation                                       │
-└─────────────────────────────────────────────────────────────────┘
-```
+It targets the modern llama.cpp C API. Functions upstream marks deprecated are
+deliberately not exposed — the binding wraps the replacement instead.
 
 ---
 
-## 📋 Requirements
+## Requirements
 
-- Go 1.20+
-- C/C++ compiler (GCC, Clang, or MSVC)
-- CMake 3.14+
-- (Optional) CUDA Toolkit for NVIDIA GPU support
-- (Optional) ROCm for AMD GPU support
+| | |
+|---|---|
+| **Go** | 1.25 or newer (the `go` directive in `go.mod`; older toolchains will fetch it) |
+| **C++ compiler** | GCC, Clang, or Apple Clang, with C++17 support |
+| **CMake** | 3.14+ (builds the vendored llama.cpp) |
+| **Optional** | CUDA Toolkit, ROCm, or Xcode for GPU backends |
 
 ---
 
-## 🎯 Quick Start
+## Quick start
 
-### Installation
+This is **not a `go get`-only package.** It links against a static library
+built from the vendored llama.cpp submodule, so you clone and build first:
 
 ```bash
-# Clone with submodules
 git clone --recurse-submodules https://github.com/AshkanYarmoradi/go-llama.cpp
 cd go-llama.cpp
-
-# Build the bindings
 make libbinding.a
-
-# Run the example
-LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m "/path/to/model.gguf" -t 8
 ```
 
-### Basic Usage
+Then build or run with the library on the search path:
+
+```bash
+LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m /path/to/model.gguf -t 8
+```
+
+To use it from your own module, add a `replace` directive pointing at your
+checkout and set the same two environment variables when you build.
+
+---
+
+## Generating text
 
 ```go
 package main
 
 import (
     "fmt"
+
     llama "github.com/AshkanYarmoradi/go-llama.cpp"
 )
 
 func main() {
-    // Load model
     model, err := llama.New("model.gguf",
-        llama.SetContext(2048),
+        llama.SetContext(4096),
         llama.SetGPULayers(35),
     )
     if err != nil {
@@ -123,8 +90,7 @@ func main() {
     }
     defer model.Free()
 
-    // Generate text
-    response, err := model.Predict("Explain quantum computing in simple terms:",
+    out, err := model.Predict("Explain quantum computing in simple terms:",
         llama.SetTemperature(0.7),
         llama.SetTopP(0.9),
         llama.SetTokens(256),
@@ -132,228 +98,342 @@ func main() {
     if err != nil {
         panic(err)
     }
-    
-    fmt.Println(response)
+    fmt.Println(out)
 }
 ```
 
----
+### Streaming
 
-## 🎛️ API Reference
-
-### New Sampler Options
+Return `false` from the callback to stop generation early.
 
 ```go
-// XTC (Cross-Token Coherence) - Improves coherence between tokens
-llama.SetXTC(probability, threshold float64)
-
-// DRY (Don't Repeat Yourself) - Reduces repetitive patterns  
-llama.SetDRY(multiplier, base float64, allowedLength, penaltyLastN int)
-
-// TopNSigma - Statistical sampling based on standard deviations
-llama.SetTopNSigma(n float64)
+model.SetTokenCallback(func(token string) bool {
+    fmt.Print(token)
+    return true
+})
+model.Predict("Write a story about a robot:", llama.SetTokens(500))
 ```
 
-### Model Information API
+### Chat models
+
+`ApplyChatTemplate` renders a conversation using the template stored in the
+model's own GGUF metadata, so you do not hardcode any one model's prompt
+format. Pass a name (from `BuiltinChatTemplates()`) to override it.
 
 ```go
-// Get comprehensive model metadata
-info := model.GetModelInfo()
-fmt.Printf("Model: %s\n", info.Description)
-fmt.Printf("Vocabulary: %d tokens\n", info.VocabSize)
-fmt.Printf("Context Length: %d\n", info.ContextLength)
-fmt.Printf("Embedding Dim: %d\n", info.EmbeddingSize)
-fmt.Printf("Layers: %d\n", info.LayerCount)
-fmt.Printf("Attention Heads: %d (KV: %d)\n", info.HeadCount, info.HeadCountKV)
-fmt.Printf("Parameters: %d\n", info.ParamCount)
-fmt.Printf("Size: %d bytes\n", info.ModelSize)
+prompt, err := model.ApplyChatTemplate("", []llama.ChatMessage{
+    {Role: "system", Content: "You are terse."},
+    {Role: "user", Content: "How much is 2+2?"},
+}, true) // true: end with the assistant turn opener
 
-// Read the raw GGUF key-value metadata header
-meta := model.ModelMetadata()
-fmt.Printf("Architecture: %s\n", meta["general.architecture"])
-if name, ok := model.ModelMetadataValue("general.name"); ok {
-    fmt.Printf("Name: %s\n", name)
+out, _ := model.Predict(prompt)
+```
+
+llama.cpp recognises a fixed set of templates rather than running a full Jinja
+engine. A model whose template it cannot place returns `ErrNoChatTemplate` —
+format the prompt yourself in that case.
+
+### Embeddings
+
+```go
+model, _ := llama.New("model.gguf", llama.EnableEmbeddings)
+vec, _ := model.Embeddings("The quick brown fox")
+```
+
+> A context configured for embeddings does not produce usable logits, so
+> `Predict` on it returns garbage. Load the model twice if you need both, or
+> flip the context with `SetEmbeddings`.
+
+---
+
+## Driving inference yourself
+
+For anything `Predict` cannot express — several conversations sharing one
+context, speculative decoding, custom stopping rules — build a batch, decode
+it, and sample.
+
+```go
+tokens := model.Tokenize("The capital of France is", true, false)
+
+batch := llama.NewBatch(len(tokens), 1)
+defer batch.Free()
+for i, tok := range tokens {
+    batch.Add(tok, int32(i), []int32{0}, i == len(tokens)-1)
+}
+if model.Decode(batch) != 0 {
+    panic("decode failed")
 }
 
-// Special tokens, including PAD, MASK and fill-in-the-middle
-tokens := model.GetSpecialTokens()
-fmt.Printf("BOS=%d EOS=%d EOT=%d FIMPre=%d\n", tokens.BOS, tokens.EOS, tokens.EOT, tokens.FIMPre)
+chain := llama.NewSamplerChain()
+defer chain.Free()
+chain.Add(llama.SamplerTopK(40))
+chain.Add(llama.SamplerTopP(0.95, 1))
+chain.Add(model.SamplerPenalties(64, 1.1, 0, 0))
+chain.Add(llama.SamplerTemp(0.8))
+chain.Add(llama.SamplerDist(1234))
 
-// Get chat template for chat models
-// Pass "" for the default template, or a name for a specific one
-template := model.GetChatTemplate("")
-
-// Backend capabilities — these need no loaded model
-fmt.Printf("mmap=%v mlock=%v gpuOffload=%v maxDevices=%d\n",
-    llama.SupportsMmap(), llama.SupportsMlock(),
-    llama.SupportsGPUOffload(), llama.MaxDevices())
+next := chain.Sample(model, -1)
+chain.Accept(next)
+fmt.Print(model.TokenToPiece(next, false))
 ```
 
-### All Sampling Options
+A chain **owns** every stage added to it — `chain.Free()` frees them all, and a
+stage must not be freed separately after `Add`.
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `SetTemperature(t)` | Randomness (0.0 = deterministic) | 0.8 |
-| `SetTopK(k)` | Limit to top K tokens | 40 |
-| `SetTopP(p)` | Nucleus sampling threshold | 0.9 |
-| `SetMinP(p)` | Minimum probability threshold | 0.05 |
-| `SetRepeatPenalty(p)` | Penalize repeated tokens | 1.1 |
-| `SetPresencePenalty(p)` | Penalize token presence | 0.0 |
-| `SetFrequencyPenalty(p)` | Penalize token frequency | 0.0 |
-| `SetXTC(prob, thresh)` | Cross-token coherence | disabled |
-| `SetDRY(...)` | Don't Repeat Yourself | disabled |
-| `SetTopNSigma(n)` | Statistical sigma sampling | disabled |
-| `SetMirostat(mode)` | Mirostat sampling (1 or 2) | disabled |
-| `SetMirostatTAU(tau)` | Mirostat target entropy | 5.0 |
-| `SetMirostatETA(eta)` | Mirostat learning rate | 0.1 |
+> **Stop on `model.IsEOG(tok)`, not on `tok == EOS`.** Many models define
+> several end-of-turn tokens; `IsEOG` asks the vocabulary about all of them.
+
+### Sequences and the KV cache
+
+A context holds several independent conversations, each identified by a
+sequence id in `[0, ContextParams().NSeqMax)`.
+
+```go
+model.MemorySeqCopy(0, 1, 0, -1)  // fork sequence 0 into 1, sharing the prefix
+model.MemorySeqRemove(1, -1, -1)  // drop sequence 1 entirely
+```
+
+Context shifting — making room by dropping the oldest tokens — is an evict
+followed by a slide:
+
+```go
+if model.MemoryCanShift() {
+    model.MemorySeqRemove(0, 0, nDiscard)
+    model.MemorySeqAdd(0, nDiscard, -1, -nDiscard)
+}
+```
+
+### Checkpointing one conversation
+
+Whole-context state grows with the entire KV cache. Per-sequence state captures
+a single slot, and restores into any sequence id:
+
+```go
+data, _ := model.SequenceStateData(0)
+model.SetSequenceStateData(data, 1)
+
+// Or to disk, with the token list alongside it.
+model.SaveSequenceFile("slot0.bin", 0, tokens)
+tokens, _ = model.LoadSequenceFile("slot0.bin", 0)
+```
 
 ---
 
-## ⚠️ Important Notes
+## Concurrency
 
-### GGUF Format Only
+**A `*LLama` is not safe for concurrent use.** Each context has one KV cache and
+one output buffer, so concurrent `Predict` or `Decode` calls on the same model
+corrupt each other. Serialize with a mutex, or give each goroutine its own
+context.
 
-This library works **exclusively** with the modern `gguf` file format. The legacy `ggml` format is no longer supported.
-
-> Need `ggml` support? Use the legacy tag: [`pre-gguf`](https://github.com/AshkanYarmoradi/go-llama.cpp/releases/tag/pre-gguf)
-
-### Converting Models
-
-```bash
-# Convert HuggingFace models to GGUF
-python llama.cpp/convert_hf_to_gguf.py /path/to/model --outfile model.gguf
-
-# Quantize for smaller size
-./llama.cpp/build/bin/llama-quantize model.gguf model-q4_k_m.gguf Q4_K_M
-```
+Distinct sequence ids isolate *conversations*, not *callers* — they still need
+serializing.
 
 ---
 
-## ⚡ Acceleration
+## GPU backends
 
-### CPU (Default)
+Pick a `BUILD_TYPE`, rebuild `libbinding.a`, and pass the matching linker
+flags. Use `llama.SupportsGPUOffload()` at runtime to check what the library
+was actually compiled with.
 
-The default build uses optimized CPU code with automatic SIMD detection.
+<details>
+<summary><b>CPU (default)</b></summary>
 
 ```bash
 make libbinding.a
-LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m "model.gguf" -t 8
+LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m model.gguf -t 8
 ```
+</details>
 
-### OpenBLAS
-
-```bash
-BUILD_TYPE=openblas make libbinding.a
-CGO_LDFLAGS="-lopenblas" LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run -tags openblas ./examples -m "model.gguf" -t 8
-```
-
-### 🟢 NVIDIA CUDA
+<details>
+<summary><b>NVIDIA CUDA</b></summary>
 
 ```bash
 BUILD_TYPE=cublas make libbinding.a
 CGO_LDFLAGS="-lcublas -lcudart -L/usr/local/cuda/lib64/" \
-  LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m "model.gguf" -ngl 35
+  LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m model.gguf -ngl 35
 ```
+</details>
 
-### 🔴 AMD ROCm
+<details>
+<summary><b>AMD ROCm</b></summary>
 
 ```bash
 BUILD_TYPE=hipblas make libbinding.a
 CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ \
   CGO_LDFLAGS="-O3 --hip-link --rtlib=compiler-rt -unwindlib=libgcc -lrocblas -lhipblas" \
-  LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m "model.gguf" -ngl 64
+  LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m model.gguf -ngl 64
 ```
+</details>
 
-### 🔵 Intel OpenCL
-
-```bash
-BUILD_TYPE=clblas CLBLAS_DIR=/path/to/clblast make libbinding.a
-CGO_LDFLAGS="-lOpenCL -lclblast -L/usr/local/lib64/" \
-  LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m "model.gguf"
-```
-
-### 🍎 Apple Metal (M1/M2/M3)
+<details>
+<summary><b>Apple Metal (M1/M2/M3)</b></summary>
 
 ```bash
 BUILD_TYPE=metal make libbinding.a
 CGO_LDFLAGS="-framework Foundation -framework Metal -framework MetalKit -framework MetalPerformanceShaders" \
   LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go build ./examples/main.go
 cp build/bin/ggml-metal.metal .
-./main -m "model.gguf" -ngl 1
+./main -m model.gguf -ngl 1
+```
+</details>
+
+<details>
+<summary><b>OpenBLAS</b></summary>
+
+```bash
+BUILD_TYPE=openblas make libbinding.a
+CGO_LDFLAGS="-lopenblas" LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD \
+  go run -tags openblas ./examples -m model.gguf -t 8
+```
+</details>
+
+<details>
+<summary><b>Intel OpenCL / CLBlast</b></summary>
+
+```bash
+BUILD_TYPE=clblas CLBLAS_DIR=/path/to/clblast make libbinding.a
+CGO_LDFLAGS="-lOpenCL -lclblast -L/usr/local/lib64/" \
+  LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go run ./examples -m model.gguf
+```
+</details>
+
+---
+
+## API reference
+
+Full documentation is on
+[pkg.go.dev](https://pkg.go.dev/github.com/AshkanYarmoradi/go-llama.cpp). This
+is a map of what exists.
+
+### Generation
+
+| | |
+|---|---|
+| `New(path, ...ModelOption)` / `Free()` | load and release a model |
+| `Predict(text, ...PredictOption)` | generate in one call |
+| `SetTokenCallback(fn)` | stream tokens; return false to stop |
+| `Embeddings(text)` / `TokenEmbeddings(tokens)` | embedding vectors |
+| `ApplyChatTemplate(tmpl, msgs, addAssistant)` | render a conversation |
+| `BuiltinChatTemplates()` / `GetChatTemplate(name)` | template discovery |
+
+### Tokenization
+
+`Tokenize` · `Detokenize` · `TokenToPiece` · `TokenizeString`
+
+### Low-level inference
+
+| | |
+|---|---|
+| `NewBatch(maxTokens, maxSeq)`, `Add`, `Reset`, `Len`, `Free` | batch assembly |
+| `Decode(batch)` / `Encode(batch)` | run the graph |
+| `Logits(i)` · `TokenEmbedding(i)` · `SequenceEmbedding(seq)` | outputs |
+| `Synchronize()` | wait for queued computation |
+
+### Sampling
+
+Chain: `NewSamplerChain`, `Add`, `Sample`, `Accept`, `Reset`, `Free`, `Perf`.
+
+Stages: `SamplerGreedy` · `SamplerDist` · `SamplerTopK` · `SamplerTopP` ·
+`SamplerMinP` · `SamplerTypical` · `SamplerTemp` · `SamplerTempExt` ·
+`SamplerXTC` · `SamplerTopNSigma` · `SamplerMirostatV2` ·
+`SamplerPenalties`\* · `SamplerGrammar`\* · `SamplerDRY`\*
+
+\* methods on `*LLama` — they need the model's vocabulary.
+
+### KV cache
+
+`MemoryClear` · `MemorySeqRemove` · `MemorySeqCopy` · `MemorySeqKeep` ·
+`MemorySeqAdd` · `MemorySeqDiv` · `MemorySeqPosMin` · `MemorySeqPosMax` ·
+`MemoryCanShift`
+
+### State persistence
+
+`StateSize` · `StateData` · `SetStateData` · `SaveSessionFile` ·
+`LoadSessionFile` · `SequenceStateSize` · `SequenceStateData` ·
+`SetSequenceStateData` · `SaveSequenceFile` · `LoadSequenceFile`
+
+### Introspection
+
+| | |
+|---|---|
+| `GetModelInfo()` | vocab size, layers, heads, parameters, size |
+| `Architecture()` | RoPE type, file type, encoder/decoder, recurrent/hybrid |
+| `ContextParams()` | the geometry the context *actually* uses |
+| `ModelMetadata()` / `ModelMetadataValue(key)` | raw GGUF key-value header |
+| `VocabType()` · `TokenText` · `TokenScore` · `TokenAttr` | vocabulary details |
+| `IsEOG` · `IsControlToken` · `SuppressTokens` | token classification |
+| `GetSpecialTokens()` | BOS, EOS, EOT, PAD, MASK, FIM tokens |
+| `Perf()` / `PerfReset()` | prompt-eval and eval timings and counts |
+
+### Runtime control
+
+`Threads` / `SetThreads` · `SetEmbeddings` · `SetCausalAttn` · `ApplyLoRA` /
+`ClearLoRA`
+
+### Package level
+
+`Version()` · `TimeUS()` · `SystemInfo()` · `SupportsMmap` · `SupportsMlock` ·
+`SupportsGPUOffload` · `SupportsRPC` · `MaxDevices` · `MaxParallelSequences` ·
+`FileTypeName` · `FlashAttnTypeName`
+
+### Sampling options for `Predict`
+
+| Option | Description | Default |
+|---|---|---|
+| `SetTemperature(t)` | randomness; ≤ 0 selects greedy | 0.8 |
+| `SetTopK(k)` | keep the k likeliest tokens | 40 |
+| `SetTopP(p)` | nucleus sampling threshold | 0.95 |
+| `SetMinP(p)` | minimum probability relative to the best token | 0.05 |
+| `SetPenalty(p)` | repetition penalty (1.0 disables) | 1.1 |
+| `SetPresencePenalty(p)` | flat penalty for any seen token | 0.0 |
+| `SetFrequencyPenalty(p)` | penalty scaled by occurrence count | 0.0 |
+| `SetTypicalP(p)` | locally typical sampling | 1.0 |
+| `SetXTCProbability(p)` / `SetXTCThreshold(t)` | exclude-top-choices sampling | disabled |
+| `SetDRYMultiplier(m)` / `SetDRYBase(b)` / `SetDRYAllowedLength(n)` / `SetDRYPenaltyLastN(n)` | DRY repetition penalty | disabled |
+| `SetTopNSigma(n)` | keep tokens within n standard deviations | disabled |
+| `SetMirostat(mode)` | Mirostat v1 or v2 | disabled |
+| `SetMirostatTAU(tau)` | Mirostat target entropy | 5.0 |
+| `SetMirostatETA(eta)` | Mirostat learning rate | 0.1 |
+| `WithGrammar(gbnf)` | constrain output to a GBNF grammar | none |
+| `SetStopWords(...)` | stop generation at any of these strings | none |
+| `SetLogitBias(spec)` | bias specific tokens, as `token(+\|-)value` | none |
+
+---
+
+## Models
+
+Only the **GGUF** format is supported; legacy `ggml` files are not. For those,
+use the [`pre-gguf`](https://github.com/AshkanYarmoradi/go-llama.cpp/releases/tag/pre-gguf)
+tag.
+
+```bash
+# Convert a Hugging Face model
+python llama.cpp/convert_hf_to_gguf.py /path/to/model --outfile model.gguf
+
+# Quantize it
+./llama.cpp/build/bin/llama-quantize model.gguf model-q4_k_m.gguf Q4_K_M
 ```
 
----
-
-## 📖 Examples
-
-### Streaming Output
-
-```go
-model.SetTokenCallback(func(token string) bool {
-    fmt.Print(token)
-    return true // continue generation
-})
-
-model.Predict("Write a story about a robot:",
-    llama.SetTokens(500),
-    llama.SetTemperature(0.8),
-)
-```
-
-### Embeddings
-
-```go
-model, _ := llama.New("model.gguf", llama.EnableEmbeddings)
-
-embeddings, _ := model.Embeddings("The quick brown fox")
-fmt.Printf("Vector dimension: %d\n", len(embeddings))
-```
-
-> **Note:** A model loaded with `EnableEmbeddings` cannot generate text. The context
-> returns pooled embeddings instead of token logits, so `Predict` produces garbage
-> output. If you need both, load the model twice — once with `EnableEmbeddings` and
-> once without.
-
-### With LoRA Adapter
-
-```go
-model, _ := llama.New("base-model.gguf",
-    llama.SetLoraAdapter("adapter.bin"),
-    llama.SetLoraBase("base-model.gguf"),
-)
-```
+Ready-made GGUF models: [Hugging Face](https://huggingface.co/models?library=gguf).
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
-Contributions are welcome! This fork is actively maintained and I'm happy to review PRs for:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, how to run
+the tests against a real model, and what CI checks.
 
-- Bug fixes
-- Performance improvements  
-- New llama.cpp feature bindings
-- Documentation improvements
-- Test coverage
+Security issues: see [SECURITY.md](SECURITY.md).
 
 ---
 
-## 📚 Resources
+## License
 
-- **[llama.cpp](https://github.com/ggerganov/llama.cpp)** — The C++ inference engine
-- **[GGUF Format](https://github.com/ggerganov/ggml/blob/master/docs/gguf.md)** — Model file format specification
-- **[Hugging Face GGUF Models](https://huggingface.co/models?library=gguf)** — Pre-quantized models
-
----
-
-## 📄 License
-
-MIT License — see [LICENSE](LICENSE) for details.
-
----
+MIT — see [LICENSE](LICENSE).
 
 <div align="center">
-
-**Built with 🦙 by the Go + LLM community**
 
 *If you find this useful, consider giving it a ⭐*
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report security issues through
+[GitHub's private vulnerability reporting](https://github.com/AshkanYarmoradi/go-llama.cpp/security/advisories/new)
+rather than a public issue.
+
+Please include what you have: the affected version or commit, what an attacker
+gains, and a reproducer if you have one. I will acknowledge within a few days
+and keep you updated as a fix comes together.
+
+## Supported versions
+
+This project tracks llama.cpp's `master`. Fixes land on `main`; there are no
+maintained release branches. If you are pinned to an older commit, the fix is
+to move forward.
+
+## Scope
+
+This repository is a binding layer. Roughly:
+
+**In scope** — bugs in this repo's own code:
+
+- Memory safety in `binding.cpp`: unchecked buffer sizes, out-of-bounds
+  indexing, use-after-free, or missing bounds checks on caller-supplied
+  indices and token ids.
+- Unsafe pointer handling in `llama.go`, including slices passed to C that Go
+  may move or free.
+- The build system fetching or executing something it should not.
+
+**Out of scope** — report these to
+[ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp/security) instead:
+
+- Vulnerabilities in the llama.cpp engine itself or in ggml.
+- Malicious GGUF model files. Model parsing happens entirely inside llama.cpp.
+
+## Things that are not vulnerabilities
+
+Worth stating, because they come up:
+
+- **Model output.** What a language model generates is not a security boundary.
+  Prompt injection, jailbreaks, and harmful completions are properties of the
+  model, not of this binding.
+- **Loading an untrusted model.** A GGUF file is executable-adjacent input to a
+  large C++ parser. Treat model files like any other untrusted binary: only
+  load ones you trust the source of.
+- **Concurrent misuse.** A `*LLama` is documented as not safe for concurrent
+  use. Data races from calling it concurrently are a usage error, not a
+  vulnerability.

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,134 @@
+/*
+Package llama provides Go bindings for [llama.cpp], the C++ inference engine
+for GGUF models.
+
+It exposes two layers. The high-level layer runs a whole generation in one
+call and is what most programs want. The low-level layer maps onto llama.cpp's
+own primitives — batches, decoding, the KV cache, sampler chains — for programs
+that need to drive inference themselves, such as servers juggling several
+conversations in one context.
+
+# Building
+
+The binding links against a static library built from the vendored llama.cpp
+submodule, so it is not a `go get`-only package:
+
+	git clone --recurse-submodules https://github.com/AshkanYarmoradi/go-llama.cpp
+	cd go-llama.cpp
+	make libbinding.a
+
+Then build your program with the library on the search path:
+
+	LIBRARY_PATH=$PWD C_INCLUDE_PATH=$PWD go build ./...
+
+See the README for GPU backends (CUDA, ROCm, Metal, OpenCL, OpenBLAS).
+
+# Generating text
+
+Load a model, generate, free it. [LLama.Free] releases the model and context;
+without it the memory lives until the process exits.
+
+	model, err := llama.New("model.gguf",
+		llama.SetContext(4096),
+		llama.SetGPULayers(35),
+	)
+	if err != nil {
+		return err
+	}
+	defer model.Free()
+
+	out, err := model.Predict("Explain quantum computing:",
+		llama.SetTemperature(0.7),
+		llama.SetTokens(256),
+	)
+
+[LLama.SetTokenCallback] streams tokens as they are produced; returning false
+from the callback stops generation early.
+
+# Chat models
+
+[LLama.ApplyChatTemplate] renders a conversation with the template stored in
+the model's own GGUF metadata, so you do not have to hardcode one model's
+prompt format:
+
+	prompt, err := model.ApplyChatTemplate("", []llama.ChatMessage{
+		{Role: "system", Content: "You are terse."},
+		{Role: "user", Content: "How much is 2+2?"},
+	}, true)
+
+llama.cpp recognises a fixed set of templates rather than running a full Jinja
+engine, so a model whose template it cannot place returns [ErrNoChatTemplate].
+
+# Driving inference directly
+
+For anything Predict cannot express — several conversations sharing one
+context, speculative decoding, custom stopping rules — build a batch, decode
+it, and sample:
+
+	chain := llama.NewSamplerChain()
+	defer chain.Free()
+	chain.Add(llama.SamplerTopK(40))
+	chain.Add(llama.SamplerTopP(0.95, 1))
+	chain.Add(model.SamplerPenalties(64, 1.1, 0, 0))
+	chain.Add(llama.SamplerTemp(0.8))
+	chain.Add(llama.SamplerDist(seed))
+
+	batch := llama.NewBatch(len(tokens), 1)
+	defer batch.Free()
+	for i, tok := range tokens {
+		batch.Add(tok, int32(i), []int32{0}, i == len(tokens)-1)
+	}
+	if model.Decode(batch) != 0 {
+		return errors.New("decode failed")
+	}
+
+	next := chain.Sample(model, -1)
+	chain.Accept(next)
+
+A sampler chain owns every stage added to it: [Sampler.Free] on the chain frees
+them all, and a stage must not be freed separately after [Sampler.Add].
+
+Stop on [LLama.IsEOG] rather than comparing against EOS. Many models define
+several end-of-turn tokens, and IsEOG asks the vocabulary about all of them.
+
+# Sequences and the KV cache
+
+A context holds several sequences, each an independent conversation identified
+by a sequence id in [0, ContextParams.NSeqMax). The Memory methods manage them:
+[LLama.MemorySeqRemove] evicts a range, [LLama.MemorySeqCopy] shares a prefix
+between sequences, and [LLama.MemorySeqAdd] shifts positions.
+
+Context shifting — making room by dropping the oldest tokens — is those two
+together:
+
+	if model.MemoryCanShift() {
+		model.MemorySeqRemove(0, 0, nDiscard)
+		model.MemorySeqAdd(0, nDiscard, -1, -nDiscard)
+	}
+
+[LLama.SequenceStateData] checkpoints one sequence without serializing the
+others, and [LLama.SetSequenceStateData] restores it into any sequence id.
+
+# Embeddings
+
+Load with [EnableEmbeddings] and call [LLama.Embeddings]. A context configured
+for embeddings does not produce usable logits, so Predict on it returns
+garbage; load the model twice if you need both, or flip the context with
+[LLama.SetEmbeddings].
+
+# Concurrency
+
+A [LLama] value is not safe for concurrent use. Each context has one KV cache
+and one output buffer, so concurrent Predict or Decode calls on the same model
+corrupt each other. Serialize access with a mutex, or give each goroutine its
+own context. Distinct sequence ids within one context isolate conversations,
+not callers — they still need serializing.
+
+# Engine coverage
+
+The binding tracks llama.cpp's C API. Functions llama.cpp marks deprecated are
+deliberately not exposed; use the replacement the engine points at.
+
+[llama.cpp]: https://github.com/ggerganov/llama.cpp
+*/
+package llama


### PR DESCRIPTION
Stacked on #211 -> #210 -> #209 -> #208 -> #207 -> #206.

## The README documented an API that does not exist

| README said | Actually |
|---|---|
| `SetXTC(prob, thresh)` | `SetXTCProbability` + `SetXTCThreshold` |
| `SetDRY(...)` | `SetDRYMultiplier` / `SetDRYBase` / `SetDRYAllowedLength` / `SetDRYPenaltyLastN` |
| `SetGrammar(gbnf)` | `WithGrammar(gbnf)` |
| `SetRepeatPenalty(p)` | `SetPenalty(p)` |
| `SetTopP` default `0.9` | `0.95` |
| Requires Go 1.20+ | `go.mod` requires 1.25 |

The feature list also ended with a literal `- ✅ ................`.

Everything the README now names is **checked against the source** — every backticked identifier and every `model.X` in an example resolves to a real exported symbol.

## It documented almost none of what the binding does

No mention of composable samplers (#184), low-level batching (#183), multi-LoRA (#182) or direct tokenization (#180) — four of the last five features shipped. The rewrite covers those plus everything in this stack, organised around what a reader is trying to *do* rather than around which PR added what.

## doc.go

There was no package documentation at all, so pkg.go.dev showed nothing. It now covers the two layers, the build requirement (this is **not** a `go get`-only package), chat templates, driving inference directly, sequences and the KV cache, and that **a `*LLama` is not safe for concurrent use** — which was previously written down nowhere.

Three things are called out explicitly because getting them wrong fails *silently*:

- **Stop on `IsEOG`, not `tok == EOS`.** Models define several end-of-turn tokens.
- **A sampler chain owns its stages** — do not free a stage after `Add`.
- **An embeddings context does not produce usable logits.**

## CONTRIBUTING.md

The three-layer structure (`binding.cpp` -> `binding.h` -> `llama.go`), the two buffer conventions and when each applies, the `static_assert` rule for mirrored enums, the pre-push checks, and — since it is the recurring maintenance task here — **what to do when Dependabot's daily submodule bump breaks the build**.

## SECURITY.md

Draws the boundary that matters for a binding: memory safety in `binding.cpp` is in scope; llama.cpp and ggml bugs go upstream; model output is not a security boundary.

## Also

`CHANGELOG.md`, issue templates (including one for engine API gaps), and a PR template whose checklist is literally the commands CI runs.