### PR TITLE
feat: complete the sampler surface and add chain introspection

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -1755,3 +1755,106 @@ int state_seq_load_file(void* state_ptr, const char* path, int dest_seq_id,
     }
     return (int) n_out;
 }
+
+//
+// Remaining sampler stages and chain introspection
+//
+
+// Fill-in-the-middle infill sampler. Meant to run after top-k and top-p: it
+// merges same-prefix candidates and prefers an EOG token once the infill is
+// complete, which is what stops FIM generation from running past the hole.
+void* sampler_init_infill(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    return llama_sampler_init_infill(vocab);
+}
+
+// Adaptive-p. Upstream recommends running it with min-p as the only other
+// active truncation stage in the chain.
+void* sampler_init_adaptive_p(float target, float decay, unsigned int seed) {
+    return llama_sampler_init_adaptive_p(target, decay, seed);
+}
+
+// Logit bias. biases is a flat array of n_bias (token, bias) pairs, kept flat
+// so cgo does not have to mirror llama_logit_bias.
+void* sampler_init_logit_bias(void* state_ptr, int n_bias, const int* tokens, const float* biases) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    if (n_bias < 0 || (n_bias > 0 && (tokens == nullptr || biases == nullptr))) {
+        return nullptr;
+    }
+    std::vector<llama_logit_bias> lb;
+    lb.reserve((size_t) n_bias);
+    for (int i = 0; i < n_bias; i++) {
+        lb.push_back({ tokens[i], biases[i] });
+    }
+    return llama_sampler_init_logit_bias(llama_vocab_n_tokens(vocab), n_bias, lb.data());
+}
+
+// Lazy grammar: stays inactive until one of the trigger patterns or trigger
+// tokens is seen, then constrains the rest of the output. This is how tool-call
+// grammars are applied only from the point the model starts emitting a call.
+void* sampler_init_grammar_lazy(void* state_ptr, const char* grammar, const char* root,
+                                const char** trigger_patterns, int n_patterns,
+                                const int* trigger_tokens, int n_tokens) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const llama_vocab* vocab = llama_model_get_vocab(state->model);
+    if (n_patterns < 0 || n_tokens < 0) {
+        return nullptr;
+    }
+    return llama_sampler_init_grammar_lazy_patterns(
+        vocab, grammar, root,
+        trigger_patterns, (size_t) n_patterns,
+        (const llama_token*) trigger_tokens, (size_t) n_tokens);
+}
+
+// Chain introspection. sampler_chain_get borrows a stage (the chain keeps
+// ownership); sampler_chain_remove detaches one and hands ownership to the
+// caller, who must free it.
+int sampler_chain_n(void* chain) {
+    if (chain == nullptr) {
+        return 0;
+    }
+    return llama_sampler_chain_n((const llama_sampler*) chain);
+}
+
+void* sampler_chain_get(void* chain, int i) {
+    if (chain == nullptr) {
+        return nullptr;
+    }
+    return llama_sampler_chain_get((llama_sampler*) chain, i);
+}
+
+void* sampler_chain_remove(void* chain, int i) {
+    if (chain == nullptr) {
+        return nullptr;
+    }
+    return llama_sampler_chain_remove((llama_sampler*) chain, i);
+}
+
+int sampler_name(void* smpl, char* buf, int buf_size) {
+    if (smpl == nullptr) {
+        return -1;
+    }
+    const char* name = llama_sampler_name((const llama_sampler*) smpl);
+    if (name == nullptr) {
+        return -1;
+    }
+    return snprintf(buf, (size_t) buf_size, "%s", name);
+}
+
+void* sampler_clone(void* smpl) {
+    if (smpl == nullptr) {
+        return nullptr;
+    }
+    return llama_sampler_clone((const llama_sampler*) smpl);
+}
+
+unsigned int sampler_get_seed(void* smpl) {
+    if (smpl == nullptr) {
+        return LLAMA_DEFAULT_SEED;
+    }
+    return llama_sampler_get_seed((const llama_sampler*) smpl);
+}
+
+static_assert(LLAMA_DEFAULT_SEED == 0xFFFFFFFF, "DefaultSeed out of sync with llama.go");

--- a/binding.h
+++ b/binding.h
@@ -288,6 +288,28 @@ void* sampler_init_penalties(void* state_ptr, int last_n, float repeat, float fr
 void* sampler_init_grammar(void* state_ptr, const char* grammar, const char* root);
 void* sampler_init_dry(void* state_ptr, float multiplier, float base, int allowed_length, int penalty_last_n);
 
+// Remaining sampler stages. sampler_init_logit_bias takes the (token, bias)
+// pairs as two parallel arrays. sampler_init_grammar_lazy builds a grammar
+// that stays inactive until a trigger pattern or token appears. Every
+// sampler_init_* returns NULL on invalid input, which sampler_chain_add
+// ignores.
+void* sampler_init_infill(void* state_ptr);
+void* sampler_init_adaptive_p(float target, float decay, unsigned int seed);
+void* sampler_init_logit_bias(void* state_ptr, int n_bias, const int* tokens, const float* biases);
+void* sampler_init_grammar_lazy(void* state_ptr, const char* grammar, const char* root,
+                                const char** trigger_patterns, int n_patterns,
+                                const int* trigger_tokens, int n_tokens);
+
+// Chain introspection. sampler_chain_get borrows a stage -- the chain keeps
+// ownership -- while sampler_chain_remove detaches one and transfers ownership
+// to the caller, who must free it. sampler_clone also returns an owned sampler.
+int sampler_chain_n(void* chain);
+void* sampler_chain_get(void* chain, int i);
+void* sampler_chain_remove(void* chain, int i);
+int sampler_name(void* smpl, char* buf, int buf_size);
+void* sampler_clone(void* smpl);
+unsigned int sampler_get_seed(void* smpl);
+
 #ifdef __cplusplus
 }
 

--- a/llama.go
+++ b/llama.go
@@ -510,6 +510,160 @@ func (l *LLama) SamplerDRY(multiplier, base float32, allowedLength, penaltyLastN
 		C.int(allowedLength), C.int(penaltyLastN))}
 }
 
+// SamplerInfill builds a fill-in-the-middle stage. It belongs after the
+// truncation stages (top-k, top-p): it merges candidates that share a prefix
+// and prefers an end-of-generation token once the hole is filled, which is what
+// keeps FIM generation from running past the insertion point.
+func (l *LLama) SamplerInfill() *Sampler {
+	return &Sampler{ptr: C.sampler_init_infill(l.state)}
+}
+
+// SamplerAdaptiveP builds an adaptive-p stage, which steers sampling toward
+// tokens near the target probability instead of using a fixed cutoff. target is
+// in [0, 1] (negative disables); decay is the EMA factor in [0, 0.99], giving a
+// history of roughly 1/(1-decay) tokens.
+//
+// llama.cpp recommends running it with min-p as the only other truncation stage
+// in the chain — stacking it behind top-k and top-p defeats the adaptation.
+func SamplerAdaptiveP(target, decay float32, seed uint32) *Sampler {
+	return &Sampler{ptr: C.sampler_init_adaptive_p(C.float(target), C.float(decay), C.uint(seed))}
+}
+
+// LogitBias shifts the logit of one token before sampling. A large negative
+// bias effectively bans a token; a large positive one forces it.
+type LogitBias struct {
+	Token int32
+	Bias  float32
+}
+
+// SamplerLogitBias builds a stage that applies the given biases. Put it first
+// in a chain so the adjustment is visible to every stage after it, including
+// greedy selection.
+func (l *LLama) SamplerLogitBias(biases []LogitBias) *Sampler {
+	if len(biases) == 0 {
+		return &Sampler{}
+	}
+	tokens := make([]int32, len(biases))
+	values := make([]float32, len(biases))
+	for i, b := range biases {
+		tokens[i] = b.Token
+		values[i] = b.Bias
+	}
+	return &Sampler{ptr: C.sampler_init_logit_bias(l.state, C.int(len(biases)),
+		(*C.int)(unsafe.Pointer(&tokens[0])),
+		(*C.float)(unsafe.Pointer(&values[0])))}
+}
+
+// SamplerGrammarLazy builds a grammar stage that stays inactive until the
+// output matches one of triggerPatterns (regular expressions) or produces one
+// of triggerTokens, and constrains everything from that point on.
+//
+// This is how a tool-call grammar is applied only once the model has actually
+// started emitting a call, leaving ordinary prose unconstrained.
+func (l *LLama) SamplerGrammarLazy(grammar, root string, triggerPatterns []string, triggerTokens []int32) *Sampler {
+	cG := C.CString(grammar)
+	defer C.free(unsafe.Pointer(cG))
+	cR := C.CString(root)
+	defer C.free(unsafe.Pointer(cR))
+
+	var patterns **C.char
+	if len(triggerPatterns) > 0 {
+		cPatterns := make([]*C.char, len(triggerPatterns))
+		defer func() {
+			for _, p := range cPatterns {
+				C.free(unsafe.Pointer(p))
+			}
+		}()
+		for i, p := range triggerPatterns {
+			cPatterns[i] = C.CString(p)
+		}
+		patterns = (**C.char)(unsafe.Pointer(&cPatterns[0]))
+	}
+
+	var tokens *C.int
+	if len(triggerTokens) > 0 {
+		tokens = (*C.int)(unsafe.Pointer(&triggerTokens[0]))
+	}
+
+	return &Sampler{ptr: C.sampler_init_grammar_lazy(l.state, cG, cR,
+		patterns, C.int(len(triggerPatterns)),
+		tokens, C.int(len(triggerTokens)))}
+}
+
+// Len returns the number of stages in a chain, or 0 for a single stage.
+func (s *Sampler) Len() int { return int(C.sampler_chain_n(s.ptr)) }
+
+// At returns the i-th stage of a chain without transferring ownership: the
+// returned Sampler must not be freed, and becomes invalid when the chain is.
+// It returns nil if i is out of range.
+func (s *Sampler) At(i int) *Sampler {
+	if i < 0 || i >= s.Len() {
+		return nil
+	}
+	p := C.sampler_chain_get(s.ptr, C.int(i))
+	if p == nil {
+		return nil
+	}
+	return &Sampler{ptr: p}
+}
+
+// Remove detaches the i-th stage from a chain and transfers ownership of it to
+// the caller, who must Free it. It returns nil if i is out of range.
+func (s *Sampler) Remove(i int) *Sampler {
+	if i < 0 || i >= s.Len() {
+		return nil
+	}
+	p := C.sampler_chain_remove(s.ptr, C.int(i))
+	if p == nil {
+		return nil
+	}
+	return &Sampler{ptr: p}
+}
+
+// Name returns llama.cpp's name for the stage, such as "top-k" or "dist"; a
+// chain is named "chain".
+//
+// The engine decorates the name to describe the stage's state, so match on a
+// substring rather than equality:
+//
+//	"?top-k"   the stage was built with parameters that disable it
+//	"+top-k"   it has been initialised and runs on the backend
+//	"-top-k"   it has been initialised but the backend cannot run it
+//
+// The bare name is what you see before the chain has sampled anything.
+func (s *Sampler) Name() string {
+	buf := make([]byte, 64)
+	ret := int(C.sampler_name(s.ptr, (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+	if ret <= 0 || ret > len(buf) {
+		return ""
+	}
+	return string(buf[:ret])
+}
+
+// Clone returns an independent copy of the sampler, including any accumulated
+// state, so a speculative branch can be explored without disturbing the
+// original. Cloning a chain clones every stage in it. The copy is owned by the
+// caller and must be Freed.
+//
+// Every stage this package can build implements cloning, so this cannot fail
+// for them; it returns nil only for an empty Sampler.
+func (s *Sampler) Clone() *Sampler {
+	p := C.sampler_clone(s.ptr)
+	if p == nil {
+		return nil
+	}
+	return &Sampler{ptr: p}
+}
+
+// Seed returns the RNG seed a stage was built with, or DefaultSeed for a stage
+// that does not use randomness.
+func (s *Sampler) Seed() uint32 { return uint32(C.sampler_get_seed(s.ptr)) }
+
+// DefaultSeed is llama.cpp's LLAMA_DEFAULT_SEED: the value Sampler.Seed reports
+// for a stage with no seed of its own, and the value that asks the engine to
+// pick a random one.
+const DefaultSeed uint32 = 0xFFFFFFFF
+
 // ModelInfo contains information about the loaded model
 type ModelInfo struct {
 	VocabSize          int

--- a/llama_test.go
+++ b/llama_test.go
@@ -816,6 +816,163 @@ how much is 2+2?
 		})
 	})
 
+	Context("Sampler chain introspection", func() {
+		newModel := func() *LLama {
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(model).ToNot(BeNil())
+			return model
+		}
+
+		It("reports stage names, count and seeds", func() {
+			chain := NewSamplerChain()
+			defer chain.Free()
+
+			Expect(chain.Len()).To(Equal(0))
+			Expect(chain.Name()).To(Equal("chain"))
+
+			chain.Add(SamplerTopK(40))
+			chain.Add(SamplerTemp(0.8))
+			chain.Add(SamplerDist(1234))
+			Expect(chain.Len()).To(Equal(3))
+
+			Expect(chain.At(0).Name()).To(ContainSubstring("top-k"))
+			Expect(chain.At(2).Seed()).To(Equal(uint32(1234)))
+
+			// Stages without randomness report the default seed.
+			Expect(chain.At(0).Seed()).To(Equal(DefaultSeed))
+
+			Expect(chain.At(-1)).To(BeNil())
+			Expect(chain.At(3)).To(BeNil())
+		})
+
+		It("removes a stage and hands over ownership", func() {
+			chain := NewSamplerChain()
+			defer chain.Free()
+
+			chain.Add(SamplerTopK(40))
+			chain.Add(SamplerTemp(0.8))
+			Expect(chain.Len()).To(Equal(2))
+
+			removed := chain.Remove(0)
+			Expect(removed).ToNot(BeNil())
+			Expect(removed.Name()).To(ContainSubstring("top-k"))
+			Expect(chain.Len()).To(Equal(1))
+			Expect(chain.At(0).Name()).To(ContainSubstring("temp"))
+
+			// Ownership transferred, so this is the caller's to free.
+			removed.Free()
+
+			Expect(chain.Remove(5)).To(BeNil())
+		})
+
+		It("clones a chain independently", func() {
+			chain := NewSamplerChain()
+			defer chain.Free()
+			chain.Add(SamplerTopK(40))
+			chain.Add(SamplerDist(99))
+
+			clone := chain.Clone()
+			Expect(clone).ToNot(BeNil())
+			defer clone.Free()
+
+			Expect(clone.Len()).To(Equal(2))
+			Expect(clone.At(1).Seed()).To(Equal(uint32(99)))
+
+			// Mutating the clone leaves the original alone.
+			clone.Remove(0).Free()
+			Expect(clone.Len()).To(Equal(1))
+			Expect(chain.Len()).To(Equal(2))
+		})
+
+		It("tolerates an empty sampler", func() {
+			var empty Sampler
+			Expect(empty.Len()).To(Equal(0))
+			Expect(empty.Name()).To(BeEmpty())
+			Expect(empty.Seed()).To(Equal(DefaultSeed))
+			Expect(empty.Clone()).To(BeNil())
+			empty.Free()
+		})
+
+		It("builds the model-bound stages", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			_, err := model.Predict("The capital of France is", SetTokens(4))
+			Expect(err).ToNot(HaveOccurred())
+
+			chain := NewSamplerChain()
+			defer chain.Free()
+			chain.Add(model.SamplerInfill())
+			chain.Add(SamplerAdaptiveP(0.5, 0.9, 7))
+			chain.Add(SamplerDist(1))
+			Expect(chain.Len()).To(Equal(3))
+
+			tok := chain.Sample(model, -1)
+			Expect(tok).To(BeNumerically(">=", int32(0)))
+			Expect(tok).To(BeNumerically("<", int32(model.GetModelInfo().VocabSize)))
+		})
+
+		It("bans a token with a large negative logit bias", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			_, err := model.Predict("The capital of France is", SetTokens(4))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Find what greedy would pick with no bias applied.
+			plain := NewSamplerChain()
+			plain.Add(SamplerGreedy())
+			favourite := plain.Sample(model, -1)
+			plain.Free()
+
+			// Ban it, and greedy must choose something else.
+			biased := NewSamplerChain()
+			defer biased.Free()
+			biased.Add(model.SamplerLogitBias([]LogitBias{{Token: favourite, Bias: -1e9}}))
+			biased.Add(SamplerGreedy())
+
+			Expect(biased.Sample(model, -1)).ToNot(Equal(favourite))
+		})
+
+		It("ignores an empty logit bias list", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			chain := NewSamplerChain()
+			defer chain.Free()
+			chain.Add(model.SamplerLogitBias(nil))
+			Expect(chain.Len()).To(Equal(0))
+		})
+
+		It("builds a lazy grammar stage", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			s := model.SamplerGrammarLazy(
+				`root ::= "yes" | "no"`, "root",
+				[]string{"ANSWER:"}, nil,
+			)
+			Expect(s).ToNot(BeNil())
+			chain := NewSamplerChain()
+			defer chain.Free()
+			chain.Add(s)
+			Expect(chain.Len()).To(Equal(1))
+		})
+	})
+
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {
 		getModel := func() (*LLama, error) {
 			model, err := New(


### PR DESCRIPTION
Stacked on #212 -> #211 -> #210 -> #209 -> #208 -> #207 -> #206.

Adds the four sampler stages llama.cpp offers that the binding did not, and makes a chain inspectable and copyable.

## New stages

```go
model.SamplerInfill()                        // fill-in-the-middle
llama.SamplerAdaptiveP(target, decay, seed)  // adaptive-p
model.SamplerLogitBias([]llama.LogitBias{{Token: t, Bias: -1e9}})
model.SamplerGrammarLazy(grammar, root, triggerPatterns, triggerTokens)
```

**`SamplerGrammarLazy` is the interesting one.** The grammar stays inactive until the output matches a trigger pattern or produces a trigger token, then constrains everything from that point on. That is how a tool-call grammar gets applied *only* once the model has actually started emitting a call, leaving ordinary prose unconstrained — which the eager `SamplerGrammar` cannot express.

`SamplerLogitBias` complements the existing `SetLogitBias` predict option (which takes a `token(+|-)value` string): the composable API gets a typed `[]LogitBias` instead of a string to parse.

## Chain introspection

```go
chain.Len()      // number of stages
chain.At(i)      // borrow a stage  — chain keeps ownership
chain.Remove(i)  // detach a stage  — caller now owns it, must Free
chain.Name()     // "chain", "top-k", ...
chain.Seed()     // the RNG seed, or DefaultSeed
chain.Clone()    // independent copy, including accumulated state
```

Ownership is spelled out in the doc comments because the two accessors genuinely differ — `At` borrows, `Remove` transfers. `Clone` is what makes speculative decoding expressible: branch the sampler, explore, discard the branch.

## Names are decorated, and the docs say so

v0.3.0 decorates stage names to describe their state (`llama-sampler.cpp:537`):

| | |
|---|---|
| `?top-k` | built with parameters that disable it |
| `+top-k` | initialised, runs on the backend |
| `-top-k` | initialised, backend cannot run it |

Rather than assert a name that changes the moment you sample, `Name`'s doc comment says to match on a substring, and the tests do exactly that.

## Safety

- All six new C accessors null-check their sampler argument, so calling them on a zero `Sampler` returns an empty result instead of dereferencing null. Covered by a test.
- `llama_sampler_clone` `GGML_ABORT`s for a sampler without clone support — a hard process kill. I checked all 20 built-in sampler interfaces: every one implements `clone`, so that path is unreachable from this binding. `Clone`'s doc comment states this rather than leaving it as an unexamined risk.
- `DefaultSeed` mirrors `LLAMA_DEFAULT_SEED` and is `static_assert`ed against the header, like the other mirrored constants.

## Engine APIs newly covered (10)

`llama_sampler_init_infill`, `llama_sampler_init_adaptive_p`, `llama_sampler_init_logit_bias`, `llama_sampler_init_grammar_lazy_patterns`, `llama_sampler_chain_n`, `llama_sampler_chain_get`, `llama_sampler_chain_remove`, `llama_sampler_name`, `llama_sampler_clone`, `llama_sampler_get_seed`

## Verification

Eight new tests, four of which need no model. The logit-bias test is behavioural rather than structural: it finds what greedy picks unbiased, bans that exact token, and asserts greedy now picks something else.