### PR TITLE
feat: backend sampling (llama.cpp v0.3.0)

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -1858,3 +1858,85 @@ unsigned int sampler_get_seed(void* smpl) {
 }
 
 static_assert(LLAMA_DEFAULT_SEED == 0xFFFFFFFF, "DefaultSeed out of sync with llama.go");
+
+//
+// Backend sampling (llama.cpp v0.3.0, [EXPERIMENTAL] upstream)
+//
+// Normally sampling happens on the CPU: decode produces logits, they are
+// copied back to host memory, and a sampler chain picks a token. Attaching a
+// chain to a sequence lets the backend sample as part of the graph, so the
+// full vocabulary of logits never crosses the device boundary.
+//
+// The caller keeps ownership of the chain and must keep it alive for as long
+// as it is attached to the context.
+//
+
+bool set_sequence_sampler(void* state_ptr, int seq_id, void* chain) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_set_sampler(state->ctx, seq_id, (llama_sampler*) chain);
+}
+
+// Returns the token the backend sampled for the i-th output, or -1
+// (LLAMA_TOKEN_NULL) when nothing was sampled for it.
+int get_sampled_token(void* state_ptr, int i) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return llama_get_sampled_token_ith(state->ctx, i);
+}
+
+// The three accessors below share a shape: passing out = NULL returns the
+// number of available values so the caller can size a buffer, and passing a
+// buffer copies min(count, out_size) values and returns how many were written.
+// Returns 0 when the backend sampled nothing for this index.
+
+int get_sampled_probs(void* state_ptr, int i, float* out, int out_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const int n = (int) llama_get_sampled_probs_count_ith(state->ctx, i);
+    if (out == nullptr || n <= 0) {
+        return n > 0 ? n : 0;
+    }
+    const float* src = llama_get_sampled_probs_ith(state->ctx, i);
+    if (src == nullptr) {
+        return 0;
+    }
+    const int n_copy = n < out_size ? n : out_size;
+    for (int j = 0; j < n_copy; j++) {
+        out[j] = src[j];
+    }
+    return n_copy;
+}
+
+int get_sampled_logits(void* state_ptr, int i, float* out, int out_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const int n = (int) llama_get_sampled_logits_count_ith(state->ctx, i);
+    if (out == nullptr || n <= 0) {
+        return n > 0 ? n : 0;
+    }
+    const float* src = llama_get_sampled_logits_ith(state->ctx, i);
+    if (src == nullptr) {
+        return 0;
+    }
+    const int n_copy = n < out_size ? n : out_size;
+    for (int j = 0; j < n_copy; j++) {
+        out[j] = src[j];
+    }
+    return n_copy;
+}
+
+// Candidate token ids, which is what maps a probs/logits index back to a
+// vocabulary token. Its count matches the probs count.
+int get_sampled_candidates(void* state_ptr, int i, int* out, int out_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const int n = (int) llama_get_sampled_candidates_count_ith(state->ctx, i);
+    if (out == nullptr || n <= 0) {
+        return n > 0 ? n : 0;
+    }
+    const llama_token* src = llama_get_sampled_candidates_ith(state->ctx, i);
+    if (src == nullptr) {
+        return 0;
+    }
+    const int n_copy = n < out_size ? n : out_size;
+    for (int j = 0; j < n_copy; j++) {
+        out[j] = src[j];
+    }
+    return n_copy;
+}

--- a/binding.h
+++ b/binding.h
@@ -94,6 +94,20 @@ bool memory_seq_rm(void* state_ptr, int seq_id, int p0, int p1);
 void memory_seq_cp(void* state_ptr, int src, int dst, int p0, int p1);
 void memory_seq_keep(void* state_ptr, int seq_id);
 
+// Backend sampling (llama.cpp v0.3.0, [EXPERIMENTAL] upstream). Attaching a
+// sampler chain to a sequence lets the backend sample inside the graph, so the
+// full vocabulary of logits never crosses the device boundary. The caller
+// keeps ownership of the chain and must keep it alive while it is attached.
+//
+// The three array accessors take out = NULL to report the available count,
+// or a buffer to copy into, returning how many values were written. All
+// return 0 when the backend sampled nothing for that index.
+bool set_sequence_sampler(void* state_ptr, int seq_id, void* chain);
+int get_sampled_token(void* state_ptr, int i);
+int get_sampled_probs(void* state_ptr, int i, float* out, int out_size);
+int get_sampled_logits(void* state_ptr, int i, float* out, int out_size);
+int get_sampled_candidates(void* state_ptr, int i, int* out, int out_size);
+
 
 // State and session persistence. The load_state / save_state pair above
 // round-trips a whole context as raw bytes. These add what it cannot express:

--- a/llama.go
+++ b/llama.go
@@ -187,6 +187,97 @@ func (l *LLama) embeddingBuf(fn func(out []float32) int) []float32 {
 	return out[:got]
 }
 
+// SetSequenceSampler attaches a sampler chain to a sequence so the backend
+// samples inside the compute graph, instead of copying a full vocabulary of
+// logits back to host memory for the CPU to sample from. After a Decode, read
+// the result with SampledToken rather than Logits plus Sampler.Sample.
+//
+// chain must be a chain from NewSamplerChain, not a bare stage. The caller
+// keeps ownership: the chain must stay alive, and unfreed, for as long as it
+// is attached to the context.
+//
+// This is marked experimental upstream. It reports whether the engine accepted
+// the chain; a context that was not built for backend sampling returns false,
+// and CPU sampling through Sampler.Sample keeps working.
+func (l *LLama) SetSequenceSampler(seqID int32, chain *Sampler) bool {
+	if chain == nil || chain.ptr == nil {
+		return false
+	}
+	return bool(C.set_sequence_sampler(l.state, C.int(seqID), chain.ptr))
+}
+
+// SampledToken returns the token the backend sampled for the i-th output of
+// the last Decode; i = -1 selects the last. It returns -1 when the backend
+// sampled nothing for that index, which is the normal result if no sampler is
+// attached to the sequence.
+//
+// Reading a token does not advance the sampler's state — that happens when the
+// token is accepted. With multiple outputs, accept a contiguous prefix in
+// output order.
+func (l *LLama) SampledToken(i int) int32 {
+	return int32(C.get_sampled_token(l.state, C.int(i)))
+}
+
+// SampledCandidates returns the token ids the backend sampler kept for the
+// i-th output. These are what map an index in SampledProbs or SampledLogits
+// back to a vocabulary token: candidates[k] is the token whose probability is
+// probs[k]. It returns nil when the backend sampled nothing.
+func (l *LLama) SampledCandidates(i int) []int32 {
+	n := int(C.get_sampled_candidates(l.state, C.int(i), nil, 0))
+	if n <= 0 {
+		return nil
+	}
+	out := make([]int32, n)
+	got := int(C.get_sampled_candidates(l.state, C.int(i),
+		(*C.int)(unsafe.Pointer(&out[0])), C.int(n)))
+	if got <= 0 {
+		return nil
+	}
+	return out[:got]
+}
+
+// SampledProbs returns the probabilities the backend sampler produced for the
+// i-th output, aligned with SampledCandidates. It returns nil when the backend
+// produced none — a chain without a distribution stage yields no probabilities.
+func (l *LLama) SampledProbs(i int) []float32 {
+	return sampledFloats(func(out []float32) int {
+		var p *C.float
+		if len(out) > 0 {
+			p = (*C.float)(unsafe.Pointer(&out[0]))
+		}
+		return int(C.get_sampled_probs(l.state, C.int(i), p, C.int(len(out))))
+	})
+}
+
+// SampledLogits returns the logits the backend sampler kept for the i-th
+// output, aligned with SampledCandidates. Unlike Logits, which returns the
+// whole vocabulary, this is only the candidates that survived the chain. It
+// returns nil when the backend kept none.
+func (l *LLama) SampledLogits(i int) []float32 {
+	return sampledFloats(func(out []float32) int {
+		var p *C.float
+		if len(out) > 0 {
+			p = (*C.float)(unsafe.Pointer(&out[0]))
+		}
+		return int(C.get_sampled_logits(l.state, C.int(i), p, C.int(len(out))))
+	})
+}
+
+// sampledFloats probes fn for the available count, then fills a buffer of
+// exactly that size.
+func sampledFloats(fn func(out []float32) int) []float32 {
+	n := fn(nil)
+	if n <= 0 {
+		return nil
+	}
+	out := make([]float32, n)
+	got := fn(out)
+	if got <= 0 {
+		return nil
+	}
+	return out[:got]
+}
+
 // MemoryClear drops the context's KV cache. When clearData is true the
 // underlying data buffers are cleared too, not just the cell metadata.
 func (l *LLama) MemoryClear(clearData bool) {

--- a/llama_test.go
+++ b/llama_test.go
@@ -973,6 +973,89 @@ how much is 2+2?
 		})
 	})
 
+	Context("Backend sampling", func() {
+		newModel := func() *LLama {
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(model).ToNot(BeNil())
+			return model
+		}
+
+		It("rejects a nil or empty chain", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			Expect(model.SetSequenceSampler(0, nil)).To(BeFalse())
+			Expect(model.SetSequenceSampler(0, &Sampler{})).To(BeFalse())
+		})
+
+		It("reports no sampled output when no sampler is attached", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			_, err := model.Predict("The capital of France is", SetTokens(4))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Without a backend sampler these are all empty, and must say so
+			// rather than reading past a null pointer.
+			Expect(model.SampledToken(-1)).To(Equal(int32(-1)))
+			Expect(model.SampledCandidates(-1)).To(BeNil())
+			Expect(model.SampledProbs(-1)).To(BeNil())
+			Expect(model.SampledLogits(-1)).To(BeNil())
+		})
+
+		It("samples on the backend when a chain is attached", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			// The chain must outlive the attachment, so it is freed last.
+			chain := NewSamplerChain()
+			defer chain.Free()
+			chain.Add(SamplerTopK(40))
+			chain.Add(SamplerTemp(0.8))
+			chain.Add(SamplerDist(1234))
+
+			if !model.SetSequenceSampler(0, chain) {
+				Skip("this context was not built for backend sampling")
+			}
+
+			tokens := model.Tokenize("The capital of France is", true, false)
+			Expect(tokens).ToNot(BeEmpty())
+			batch := NewBatch(len(tokens), 1)
+			defer batch.Free()
+			for i, tok := range tokens {
+				Expect(batch.Add(tok, int32(i), []int32{0}, i == len(tokens)-1)).To(Succeed())
+			}
+			Expect(model.Decode(batch)).To(Equal(0))
+
+			tok := model.SampledToken(-1)
+			Expect(tok).To(BeNumerically(">=", int32(0)))
+			Expect(tok).To(BeNumerically("<", int32(model.GetModelInfo().VocabSize)))
+
+			// Candidates index the probability array, so when both are present
+			// they must be the same length and the token must be among them.
+			cands := model.SampledCandidates(-1)
+			probs := model.SampledProbs(-1)
+			if len(probs) > 0 {
+				Expect(cands).To(HaveLen(len(probs)))
+				Expect(cands).To(ContainElement(tok))
+				for _, p := range probs {
+					Expect(p).To(BeNumerically(">=", float32(0)))
+					Expect(p).To(BeNumerically("<=", float32(1)))
+				}
+			}
+		})
+	})
+
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {
 		getModel := func() (*LLama, error) {
 			model, err := New(


### PR DESCRIPTION
Stacked on #213 -> #212 -> #211 -> #210 -> #209 -> #208 -> #207 -> #206.

v0.3.0 added the ability to sample **inside the compute graph** rather than on the CPU. Attaching a chain to a sequence means the full vocabulary of logits never crosses the device boundary — on a GPU that is the single largest per-token transfer in the loop.

```go
chain := llama.NewSamplerChain()
defer chain.Free()
chain.Add(llama.SamplerTopK(40))
chain.Add(llama.SamplerDist(seed))

model.SetSequenceSampler(0, chain)
model.Decode(batch)
tok := model.SampledToken(-1)
```

`SampledCandidates`, `SampledProbs` and `SampledLogits` expose what the chain kept. Unlike `Logits`, which returns the whole vocabulary, these are only the surviving candidates — and `SampledCandidates` is what maps an index in the other two back to a token id.

## Ownership

The sharp edge, and the doc comments say so: **the context borrows the chain.** It must stay alive and unfreed for as long as it is attached.

## This is experimental upstream, and the API admits it

llama.cpp marks backend sampling `[EXPERIMENTAL]`, and a context not built for it will not accept a chain. So:

- `SetSequenceSampler` returns a `bool` rather than pretending it always works.
- The accessors return `-1` / `nil` instead of reading through the null pointers the engine hands back in that case — covered by a test that runs *without* a sampler attached.
- The behavioural test `Skip`s on a `false` return rather than failing, so it stays honest on CI runners whose backend does not support it.

## A note on `llama_decode_with_sampler`

My API audit initially flagged it as missing. It is not wrapped because **it is not a real symbol** — despite appearing in `llama.h`, it is commented out at line 1534 with `// TODO: extend in the future`. Worth recording so the next audit doesn't re-flag it.

## Engine APIs newly covered (8)

`llama_set_sampler`, `llama_get_sampled_token_ith`, `llama_get_sampled_probs_ith`, `llama_get_sampled_probs_count_ith`, `llama_get_sampled_logits_ith`, `llama_get_sampled_logits_count_ith`, `llama_get_sampled_candidates_ith`, `llama_get_sampled_candidates_count_ith`