### PR TITLE
feat: LoRA introspection, aLoRA tokens, and control vectors

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -1940,3 +1940,104 @@ int get_sampled_candidates(void* state_ptr, int i, int* out, int out_size) {
     }
     return n_copy;
 }
+
+//
+// LoRA adapter introspection and control vectors
+//
+// Adapters are addressed by their index in the set applied through
+// apply_lora_adapter, in the order they were applied. Every function here
+// returns -1 for an index outside that set.
+//
+
+int lora_adapter_count(void* state_ptr) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (int) state->lora_adapters.size();
+}
+
+// Returns the adapter at index i, or nullptr when i is out of range.
+static llama_adapter_lora* lora_at(llama_binding_state* state, int i) {
+    if (state == nullptr || i < 0 || (size_t) i >= state->lora_adapters.size()) {
+        return nullptr;
+    }
+    return state->lora_adapters[(size_t) i];
+}
+
+int lora_adapter_meta_count(void* state_ptr, int i) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_adapter_lora* a = lora_at(state, i);
+    if (a == nullptr) {
+        return -1;
+    }
+    return llama_adapter_meta_count(a);
+}
+
+// The three metadata accessors follow snprintf semantics and return -1 when
+// the adapter index, key or entry index is absent.
+int lora_adapter_meta_val_str(void* state_ptr, int i, const char* key, char* buf, int buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_adapter_lora* a = lora_at(state, i);
+    if (a == nullptr || buf_size <= 0) {
+        return -1;
+    }
+    return llama_adapter_meta_val_str(a, key, buf, (size_t) buf_size);
+}
+
+int lora_adapter_meta_key_by_index(void* state_ptr, int i, int j, char* buf, int buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_adapter_lora* a = lora_at(state, i);
+    if (a == nullptr || buf_size <= 0) {
+        return -1;
+    }
+    return llama_adapter_meta_key_by_index(a, j, buf, (size_t) buf_size);
+}
+
+int lora_adapter_meta_val_str_by_index(void* state_ptr, int i, int j, char* buf, int buf_size) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_adapter_lora* a = lora_at(state, i);
+    if (a == nullptr || buf_size <= 0) {
+        return -1;
+    }
+    return llama_adapter_meta_val_str_by_index(a, j, buf, (size_t) buf_size);
+}
+
+// Activated LoRA: the adapter only takes effect once the model has emitted its
+// invocation tokens. Returns the token count, or the negative of it when
+// max_tokens is too small, or -1 for an out-of-range adapter. A plain (non
+// activated) LoRA reports 0.
+int lora_adapter_alora_tokens(void* state_ptr, int i, int* tokens_out, int max_tokens) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_adapter_lora* a = lora_at(state, i);
+    if (a == nullptr) {
+        return -1;
+    }
+    const int n = (int) llama_adapter_get_alora_n_invocation_tokens(a);
+    if (n <= 0) {
+        return 0;
+    }
+    if (tokens_out == nullptr || n > max_tokens) {
+        return -n;
+    }
+    const llama_token* src = llama_adapter_get_alora_invocation_tokens(a);
+    if (src == nullptr) {
+        return 0;
+    }
+    for (int j = 0; j < n; j++) {
+        tokens_out[j] = src[j];
+    }
+    return n;
+}
+
+// Control vector ("steering vector"): a direction added to the residual stream
+// of layers [il_start, il_end] to push generation toward or away from some
+// behaviour. data is n_embd x n_layers, starting from layer 1. Passing data =
+// NULL clears the active vector.
+int set_control_vector(void* state_ptr, const float* data, int len, int n_embd, int il_start, int il_end) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (data == nullptr || len <= 0) {
+        return llama_set_adapter_cvec(state->ctx, nullptr, 0, 0, 0, 0);
+    }
+    if (n_embd <= 0 || len % n_embd != 0) {
+        return -1;
+    }
+    return llama_set_adapter_cvec(state->ctx, data, (size_t) len, n_embd, il_start, il_end);
+}

--- a/binding.h
+++ b/binding.h
@@ -58,6 +58,21 @@ void llama_binding_free_model(void* state);
 int apply_lora_adapter(void* state_ptr, const char* path, float scale);
 int clear_lora_adapters(void* state_ptr);
 
+// LoRA adapter introspection and control vectors. Adapters are addressed by
+// their index in the set applied through apply_lora_adapter, in application
+// order; every accessor returns -1 for an index outside that set. The metadata
+// functions follow snprintf semantics. lora_adapter_alora_tokens returns the
+// invocation-token count (0 for a plain LoRA), or the negative of it when
+// max_tokens is too small. set_control_vector takes an n_embd x n_layers
+// buffer starting from layer 1, or data = NULL to clear the active vector.
+int lora_adapter_count(void* state_ptr);
+int lora_adapter_meta_count(void* state_ptr, int i);
+int lora_adapter_meta_val_str(void* state_ptr, int i, const char* key, char* buf, int buf_size);
+int lora_adapter_meta_key_by_index(void* state_ptr, int i, int j, char* buf, int buf_size);
+int lora_adapter_meta_val_str_by_index(void* state_ptr, int i, int j, char* buf, int buf_size);
+int lora_adapter_alora_tokens(void* state_ptr, int i, int* tokens_out, int max_tokens);
+int set_control_vector(void* state_ptr, const float* data, int len, int n_embd, int il_start, int il_end);
+
 int llama_tokenize_string(void* params_ptr, void* state_pr, int* result);
 
 // Direct tokenization helpers that do not require a binding_params struct.

--- a/llama.go
+++ b/llama.go
@@ -81,6 +81,126 @@ func (l *LLama) ClearLoRA() {
 	C.clear_lora_adapters(l.state)
 }
 
+// LoRACount returns how many adapters are currently applied to the context.
+// Adapters are indexed by application order, which is the order ApplyLoRA was
+// called in since the last ClearLoRA.
+func (l *LLama) LoRACount() int {
+	return int(C.lora_adapter_count(l.state))
+}
+
+// LoRAMetadata returns the GGUF key-value header of the i-th applied adapter —
+// the rank, alpha, and whatever the training tool recorded. It returns nil for
+// an index outside the applied set.
+func (l *LLama) LoRAMetadata(i int) map[string]string {
+	n := int(C.lora_adapter_meta_count(l.state, C.int(i)))
+	if n <= 0 {
+		return nil
+	}
+	out := make(map[string]string, n)
+	for j := 0; j < n; j++ {
+		key := adapterString(func(buf []byte) int {
+			return int(C.lora_adapter_meta_key_by_index(l.state, C.int(i), C.int(j),
+				(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+		})
+		if key == "" {
+			continue
+		}
+		out[key] = adapterString(func(buf []byte) int {
+			return int(C.lora_adapter_meta_val_str_by_index(l.state, C.int(i), C.int(j),
+				(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+		})
+	}
+	return out
+}
+
+// LoRAMetadataValue returns one metadata value from the i-th applied adapter.
+// The second result reports whether the key was present.
+func (l *LLama) LoRAMetadataValue(i int, key string) (string, bool) {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	var found bool
+	v := adapterString(func(buf []byte) int {
+		ret := int(C.lora_adapter_meta_val_str(l.state, C.int(i), cKey,
+			(*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+		found = ret >= 0
+		return ret
+	})
+	return v, found
+}
+
+// LoRAInvocationTokens returns the invocation tokens of the i-th applied
+// adapter when it is an activated LoRA (aLoRA) — one that stays dormant until
+// the model emits that exact token sequence, and applies from then on.
+//
+// It returns nil for a plain LoRA, which has no invocation sequence, and for an
+// index outside the applied set.
+func (l *LLama) LoRAInvocationTokens(i int) []int32 {
+	n := int(C.lora_adapter_alora_tokens(l.state, C.int(i), nil, 0))
+	if n == 0 || n == -1 {
+		return nil
+	}
+	if n < 0 {
+		n = -n
+	}
+	out := make([]int32, n)
+	got := int(C.lora_adapter_alora_tokens(l.state, C.int(i),
+		(*C.int)(unsafe.Pointer(&out[0])), C.int(n)))
+	if got <= 0 {
+		return nil
+	}
+	return out[:got]
+}
+
+// SetControlVector applies a control (steering) vector to the context: a
+// direction added to the residual stream of layers ilStart through ilEnd
+// inclusive, which nudges generation toward or away from some behaviour
+// without retraining anything.
+//
+// data is nEmbd x nLayers floats laid out starting from layer 1, so len(data)
+// must be a multiple of nEmbd. Pass nil to clear the active vector.
+func (l *LLama) SetControlVector(data []float32, nEmbd, ilStart, ilEnd int) error {
+	if len(data) == 0 {
+		if ret := int(C.set_control_vector(l.state, nil, 0, 0, 0, 0)); ret != 0 {
+			return fmt.Errorf("llama: failed to clear the control vector (%d)", ret)
+		}
+		return nil
+	}
+	if nEmbd <= 0 || len(data)%nEmbd != 0 {
+		return fmt.Errorf("llama: control vector length %d is not a multiple of n_embd %d", len(data), nEmbd)
+	}
+	ret := int(C.set_control_vector(l.state,
+		(*C.float)(unsafe.Pointer(&data[0])), C.int(len(data)),
+		C.int(nEmbd), C.int(ilStart), C.int(ilEnd)))
+	if ret != 0 {
+		return fmt.Errorf("llama: failed to apply the control vector (%d)", ret)
+	}
+	return nil
+}
+
+// ClearControlVector removes any control vector applied to the context.
+func (l *LLama) ClearControlVector() error {
+	return l.SetControlVector(nil, 0, 0, 0)
+}
+
+// adapterString runs fn against a buffer, growing once if fn reports it needs
+// more room (snprintf semantics). It returns "" when fn reports an error.
+func adapterString(fn func(buf []byte) int) string {
+	buf := make([]byte, 256)
+	ret := fn(buf)
+	if ret < 0 {
+		return ""
+	}
+	if ret > len(buf) {
+		buf = make([]byte, ret+1)
+		ret = fn(buf)
+		if ret < 0 || ret > len(buf) {
+			return ""
+		}
+	}
+	return string(buf[:ret])
+}
+
 // Batch accumulates tokens — each with a position, sequence IDs, and a flag for
 // whether its output is wanted — for a Decode or Encode call. It wraps the
 // engine's llama_batch; call Free when done.

--- a/llama_test.go
+++ b/llama_test.go
@@ -1056,6 +1056,73 @@ how much is 2+2?
 		})
 	})
 
+	Context("Adapters and control vectors", func() {
+		newModel := func() *LLama {
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(model).ToNot(BeNil())
+			return model
+		}
+
+		It("reports an empty adapter set on a fresh model", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			Expect(model.LoRACount()).To(Equal(0))
+
+			// Every accessor must reject an index outside the applied set
+			// rather than indexing into an empty vector.
+			for _, bad := range []int{-1, 0, 99} {
+				Expect(model.LoRAMetadata(bad)).To(BeNil())
+				Expect(model.LoRAInvocationTokens(bad)).To(BeNil())
+				_, ok := model.LoRAMetadataValue(bad, "adapter.lora.alpha")
+				Expect(ok).To(BeFalse())
+			}
+		})
+
+		It("rejects a control vector whose length does not match n_embd", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			nEmbd := model.GetModelInfo().EmbeddingSize
+			Expect(nEmbd).To(BeNumerically(">", 0))
+
+			// One element short of a whole layer.
+			bad := make([]float32, nEmbd+1)
+			Expect(model.SetControlVector(bad, nEmbd, 1, 2)).To(HaveOccurred())
+			Expect(model.SetControlVector(bad, 0, 1, 2)).To(HaveOccurred())
+		})
+
+		It("applies and clears a control vector", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model := newModel()
+			defer model.Free()
+
+			info := model.GetModelInfo()
+			nEmbd := info.EmbeddingSize
+			nLayers := 2
+
+			// A zero vector is a no-op direction, so this exercises the plumbing
+			// without asserting anything about what steering does to output.
+			vec := make([]float32, nEmbd*nLayers)
+			Expect(model.SetControlVector(vec, nEmbd, 1, nLayers)).To(Succeed())
+
+			// Generation still works with a vector applied.
+			out, err := model.Predict("The capital of France is", SetTokens(4))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).ToNot(BeEmpty())
+
+			Expect(model.ClearControlVector()).To(Succeed())
+		})
+	})
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {
 		getModel := func() (*LLama, error) {
 			model, err := New(


### PR DESCRIPTION
Stacked on #214 -> #213 -> #212 -> #211 -> #210 -> #209 -> #208 -> #207 -> #206.

#182 added `ApplyLoRA` / `ClearLoRA` but left the adapters opaque: once applied, there was no way to ask what they were. And **control vectors** — llama.cpp's other adapter mechanism — had no binding at all.

## Adapter introspection

Indexed by application order:

```go
model.LoRACount()
model.LoRAMetadata(0)                        // the adapter's GGUF header
model.LoRAMetadataValue(0, "adapter.lora.alpha")
model.LoRAInvocationTokens(0)
```

`LoRAInvocationTokens` covers **activated LoRA (aLoRA)**: an adapter that stays dormant until the model emits a specific token sequence, then applies from that point on. Knowing the sequence is the whole point — without it a caller cannot tell an aLoRA from a plain LoRA, or know what triggers it. A plain LoRA reports `nil`.

## Control vectors

```go
model.SetControlVector(data, nEmbd, ilStart, ilEnd)
model.ClearControlVector()
```

A direction added to the residual stream over a layer range, steering generation without retraining anything.

The buffer layout is genuinely error-prone — `n_embd x n_layers`, starting from **layer 1**, with both layer bounds inclusive — so both layers validate that the length is a whole multiple of `n_embd` rather than letting a misshapen buffer reach the engine. The Go error names the two numbers that disagreed.

## Bounds checking

Every accessor checks its adapter index against the applied set rather than indexing the vector on the caller's word. Tested with `-1`, `0` on an empty set, and `99`.

## Engine APIs newly covered (7)

`llama_adapter_meta_count`, `llama_adapter_meta_val_str`, `llama_adapter_meta_key_by_index`, `llama_adapter_meta_val_str_by_index`, `llama_adapter_get_alora_n_invocation_tokens`, `llama_adapter_get_alora_invocation_tokens`, `llama_set_adapter_cvec`

## Note on test coverage

CI has no LoRA or aLoRA fixture, so the metadata paths are covered structurally (bounds, empty set) rather than against a real adapter. The control-vector test applies a zero vector — a no-op direction — which exercises the full plumbing without asserting anything about what steering does to output. A local run with a real adapter file is the stronger check.