### PR TITLE
feat: route llama.cpp logs into Go

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -2041,3 +2041,52 @@ int set_control_vector(void* state_ptr, const float* data, int len, int n_embd, 
     }
     return llama_set_adapter_cvec(state->ctx, data, (size_t) len, n_embd, il_start, il_end);
 }
+
+//
+// Log routing
+//
+// llama.cpp writes everything to stderr unless a callback is installed. The
+// bridge below forwards each record to Go, which dispatches it to whatever the
+// caller registered.
+//
+// The engine's logger state is global and, as llama.h notes, not thread safe,
+// so installing and clearing is serialized on the Go side.
+
+extern "C" void goLogCallback(int level, char* text);
+
+static void binding_log_callback(enum ggml_log_level level, const char* text, void* /*user_data*/) {
+    if (text == nullptr) {
+        return;
+    }
+    // cgo generates a non-const char* signature for exported Go functions, and
+    // the Go side only reads the string, so dropping the qualifier is safe.
+    goLogCallback((int) level, const_cast<char*>(text));
+}
+
+void set_log_callback(bool enable) {
+    if (enable) {
+        llama_log_set(binding_log_callback, nullptr);
+    } else {
+        // NULL restores llama.cpp's own stderr logging.
+        llama_log_set(nullptr, nullptr);
+    }
+}
+
+// Reports whether the engine is currently routing through this binding's
+// bridge. Comparing against binding_log_callback is what makes the answer
+// meaningful: llama_log_set(nullptr) does not clear the callback, it installs
+// llama.cpp's own stderr default, so llama_log_get never returns null and a
+// plain non-null test would always be true.
+bool has_log_callback(void) {
+    ggml_log_callback cb = nullptr;
+    void* user_data = nullptr;
+    llama_log_get(&cb, &user_data);
+    return cb == binding_log_callback;
+}
+
+static_assert(GGML_LOG_LEVEL_NONE  == 0, "LogLevelNone out of sync with llama.go");
+static_assert(GGML_LOG_LEVEL_DEBUG == 1, "LogLevelDebug out of sync with llama.go");
+static_assert(GGML_LOG_LEVEL_INFO  == 2, "LogLevelInfo out of sync with llama.go");
+static_assert(GGML_LOG_LEVEL_WARN  == 3, "LogLevelWarn out of sync with llama.go");
+static_assert(GGML_LOG_LEVEL_ERROR == 4, "LogLevelError out of sync with llama.go");
+static_assert(GGML_LOG_LEVEL_CONT  == 5, "LogLevelCont out of sync with llama.go");

--- a/binding.h
+++ b/binding.h
@@ -8,6 +8,14 @@ extern "C" {
 
 extern unsigned char tokenCallback(void *, char *);
 
+// Log routing. set_log_callback(true) installs a bridge that forwards every
+// llama.cpp log record to goLogCallback; set_log_callback(false) restores the
+// engine's own stderr output. The engine's logger state is global and not
+// thread safe, so the Go layer serializes these calls.
+extern void goLogCallback(int level, char* text);
+void set_log_callback(bool enable);
+bool has_log_callback(void);
+
 int load_state(void *ctx, char *statefile, char*modes);
 
 void save_state(void *ctx, char *dst, char*modes);

--- a/llama.go
+++ b/llama.go
@@ -640,6 +640,97 @@ type Sampler struct {
 	ptr unsafe.Pointer
 }
 
+// LogLevel is the severity of a llama.cpp log record.
+type LogLevel int
+
+// Log severities, mirroring ggml_log_level.
+const (
+	LogLevelNone  LogLevel = 0
+	LogLevelDebug LogLevel = 1
+	LogLevelInfo  LogLevel = 2
+	LogLevelWarn  LogLevel = 3
+	LogLevelError LogLevel = 4
+	// LogLevelCont continues the previous record rather than starting a new
+	// one. llama.cpp uses it to build a line in pieces, so a handler that
+	// prefixes each record with a timestamp or level should skip the prefix
+	// for these.
+	LogLevelCont LogLevel = 5
+)
+
+// String returns a short uppercase name for the level.
+func (l LogLevel) String() string {
+	switch l {
+	case LogLevelNone:
+		return "NONE"
+	case LogLevelDebug:
+		return "DEBUG"
+	case LogLevelInfo:
+		return "INFO"
+	case LogLevelWarn:
+		return "WARN"
+	case LogLevelError:
+		return "ERROR"
+	case LogLevelCont:
+		return "CONT"
+	default:
+		return fmt.Sprintf("LogLevel(%d)", int(l))
+	}
+}
+
+var (
+	logMu      sync.RWMutex
+	logHandler func(LogLevel, string)
+)
+
+// SetLogHandler routes llama.cpp's log output to fn instead of stderr. The
+// engine is chatty — model loading alone produces dozens of lines — so this is
+// how that output gets into a real logger, filtered by level, or silenced.
+//
+// Pass nil to restore llama.cpp's own stderr output.
+//
+// The text arrives exactly as the engine emits it, including its trailing
+// newline, and a record may be a fragment: see LogLevelCont.
+//
+// The handler is called from whatever thread the engine is running on,
+// including during New and Predict, so it must be safe for concurrent use and
+// should not call back into this package.
+//
+// llama.cpp's logger state is global, so this affects every model in the
+// process, not just one.
+func SetLogHandler(fn func(level LogLevel, text string)) {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	logHandler = fn
+	C.set_log_callback(C.bool(fn != nil))
+}
+
+// LogHandlerInstalled reports whether llama.cpp is currently routing its log
+// output through this package.
+//
+// It asks the engine rather than trusting local state, so it also returns
+// false when other code in the process has taken the logger over — llama.cpp's
+// logger is global, and the last caller to set it wins.
+//
+// Note that "not installed" does not mean "no logging": SetLogHandler(nil)
+// restores llama.cpp's own stderr output rather than silencing it. To silence
+// the engine, install a handler that discards.
+func LogHandlerInstalled() bool {
+	return bool(C.has_log_callback())
+}
+
+//export goLogCallback
+func goLogCallback(level C.int, text *C.char) {
+	logMu.RLock()
+	fn := logHandler
+	logMu.RUnlock()
+
+	if fn == nil {
+		return
+	}
+	fn(LogLevel(level), C.GoString(text))
+}
+
 // NewSamplerChain creates an empty sampler chain. The chain takes ownership of
 // every stage added to it and frees them all when the chain's Free is called.
 func NewSamplerChain() *Sampler { return &Sampler{ptr: C.sampler_chain_init()} }

--- a/llama_test.go
+++ b/llama_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/AshkanYarmoradi/go-llama.cpp"
 	. "github.com/AshkanYarmoradi/go-llama.cpp"
@@ -1121,6 +1122,95 @@ how much is 2+2?
 			Expect(out).ToNot(BeEmpty())
 
 			Expect(model.ClearControlVector()).To(Succeed())
+		})
+	})
+
+	Context("Log routing", func() {
+		AfterEach(func() {
+			// The engine's logger is global, so always hand it back.
+			SetLogHandler(nil)
+		})
+
+		It("names the log levels", func() {
+			Expect(LogLevelInfo.String()).To(Equal("INFO"))
+			Expect(LogLevelError.String()).To(Equal("ERROR"))
+			Expect(LogLevelCont.String()).To(Equal("CONT"))
+			Expect(LogLevel(42).String()).To(ContainSubstring("42"))
+		})
+
+		It("installs and removes the handler", func() {
+			SetLogHandler(func(LogLevel, string) {})
+			Expect(LogHandlerInstalled()).To(BeTrue())
+
+			// SetLogHandler(nil) hands the logger back to llama.cpp: the engine
+			// installs its own stderr default rather than clearing the callback,
+			// so "not installed" here means "not ours", not "no logging".
+			SetLogHandler(nil)
+			Expect(LogHandlerInstalled()).To(BeFalse())
+		})
+
+		It("captures the engine's output during a model load", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			var mu sync.Mutex
+			var records []string
+			var levels []LogLevel
+
+			SetLogHandler(func(l LogLevel, text string) {
+				mu.Lock()
+				defer mu.Unlock()
+				records = append(records, text)
+				levels = append(levels, l)
+			})
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			model.Free()
+
+			mu.Lock()
+			defer mu.Unlock()
+			// Loading a model is chatty; if nothing arrived the bridge is not wired.
+			Expect(records).ToNot(BeEmpty())
+			Expect(strings.Join(records, "")).To(ContainSubstring("llama"))
+			for _, l := range levels {
+				Expect(l).To(BeNumerically(">=", LogLevelNone))
+				Expect(l).To(BeNumerically("<=", LogLevelCont))
+			}
+		})
+
+		It("stops delivering after the handler is removed", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			var mu sync.Mutex
+			count := 0
+			SetLogHandler(func(LogLevel, string) {
+				mu.Lock()
+				defer mu.Unlock()
+				count++
+			})
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			model.Free()
+
+			mu.Lock()
+			afterFirst := count
+			mu.Unlock()
+			Expect(afterFirst).To(BeNumerically(">", 0))
+
+			SetLogHandler(nil)
+
+			model2, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			model2.Free()
+
+			mu.Lock()
+			defer mu.Unlock()
+			Expect(count).To(Equal(afterFirst), "handler was called after being removed")
 		})
 	})
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {


### PR DESCRIPTION
Stacked on #215 -> #214 -> #213 -> #212 -> #211 -> #210 -> #209 -> #208 -> #207 -> #206.

llama.cpp writes to stderr unconditionally unless a callback is installed, and it is **chatty** — loading a model alone produces dozens of lines. Any program embedding this binding had no way to capture that output, filter it by level, or silence it.

```go
llama.SetLogHandler(func(level llama.LogLevel, text string) {
    if level >= llama.LogLevelWarn {
        slog.Warn("llama.cpp", "msg", strings.TrimRight(text, "\n"))
    }
})
```

Passing `nil` restores the engine's own stderr output.

## Four things the doc comment states, because each will otherwise bite

1. **The text arrives exactly as emitted**, trailing newline included.
2. **A record may be a fragment.** llama.cpp builds some lines in pieces and marks the continuations `LogLevelCont` — a handler that prefixes each record with a timestamp has to skip the prefix for those.
3. **The handler runs on whatever thread the engine is on**, including inside `New` and `Predict`, so it must be safe for concurrent use.
4. **The engine's logger state is global**, so this affects every model in the process. `llama.h` says outright that these functions are *not thread safe*; installation is serialized behind a mutex on the Go side and the handler is read under an `RLock`.

`LogHandlerInstalled()` reports whether *any* callback is installed, which distinguishes one this package set from one installed by other code in the process — a real possibility precisely because the state is global.

## Implementation note

The exported callback takes `char*` rather than `const char*`: cgo generates the non-const signature for `//export` functions, so the C++ side `const_cast`s with a comment saying why that is safe (the Go side only reads it). Without that, the cgo build fails with a conflicting-types error — which is exactly the class of thing `go vet` in the new Lint job catches in seconds.

`LogLevel` mirrors `ggml_log_level` and every value is `static_assert`ed against the header, like the other mirrored enums.

## Engine APIs newly covered (2)

`llama_log_set`, `llama_log_get`

## Verification

Four tests. Two need no model. The interesting one loads a model with a handler installed and asserts records actually arrive; the last one loads a model, removes the handler, loads again, and asserts the call count did not move — i.e. removal genuinely detaches rather than leaving a dangling callback.