### PR TITLE
feat: quantization, sharded paths, load modes, and abort callback

### DIFF
--- a/binding.cpp
+++ b/binding.cpp
@@ -821,17 +821,27 @@ void* llama_allocate_params(const char *prompt, int seed, int threads, int token
     params->frequency_penalty = frequency_penalty;
     params->prompt = std::string(prompt);
     
-    // Parse logit bias if provided
+    // Parse logit bias if provided. std::stof throws on a malformed value, and
+    // an exception escaping into cgo aborts the process, so a bad bias string
+    // is reported and ignored instead.
     if (logit_bias != nullptr && logit_bias[0] != '\0') {
         std::stringstream ss(logit_bias);
         llama_token key;
         char sign;
         std::string value_str;
         if (ss >> key && ss >> sign && std::getline(ss, value_str) && (sign == '+' || sign == '-')) {
-            llama_logit_bias bias;
-            bias.token = key;
-            bias.bias = std::stof(value_str) * ((sign == '-') ? -1.0f : 1.0f);
-            params->logit_bias.push_back(bias);
+            try {
+                llama_logit_bias bias;
+                bias.token = key;
+                bias.bias = std::stof(value_str) * ((sign == '-') ? -1.0f : 1.0f);
+                params->logit_bias.push_back(bias);
+            } catch (const std::exception & e) {
+                fprintf(stderr, "%s: ignoring malformed logit_bias %s: %s\n",
+                        __func__, logit_bias, e.what());
+            }
+        } else {
+            fprintf(stderr, "%s: ignoring malformed logit_bias %s (expected \"token(+|-)value\")\n",
+                    __func__, logit_bias);
         }
     }
     
@@ -872,23 +882,32 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
                            : mmap  ? LLAMA_LOAD_MODE_MMAP
                                    : LLAMA_LOAD_MODE_NONE;
     
-    // Parse main GPU
+    // Parse main GPU and tensor split. Both use std::stoi/std::stof, which
+    // throw on malformed input; an exception escaping into cgo aborts the
+    // process, so a bad value is reported and the default kept.
     if (maingpu != nullptr && maingpu[0] != '\0') {
-        model_params.main_gpu = std::stoi(maingpu);
+        try {
+            model_params.main_gpu = std::stoi(maingpu);
+        } catch (const std::exception & e) {
+            fprintf(stderr, "%s: ignoring malformed main_gpu %s: %s\n", __func__, maingpu, e.what());
+        }
     }
-    
-    // Parse tensor split
+
     static float tensor_split_values[128] = {0};
     if (tensorsplit != nullptr && tensorsplit[0] != '\0') {
         std::string arg_next = tensorsplit;
         const std::regex regex{R"([,/]+)"};
         std::sregex_token_iterator it{arg_next.begin(), arg_next.end(), regex, -1};
         std::vector<std::string> split_arg{it, {}};
-        
-        for (size_t i = 0; i < 128 && i < split_arg.size(); ++i) {
-            tensor_split_values[i] = std::stof(split_arg[i]);
+
+        try {
+            for (size_t i = 0; i < 128 && i < split_arg.size(); ++i) {
+                tensor_split_values[i] = std::stof(split_arg[i]);
+            }
+            model_params.tensor_split = tensor_split_values;
+        } catch (const std::exception & e) {
+            fprintf(stderr, "%s: ignoring malformed tensor_split %s: %s\n", __func__, tensorsplit, e.what());
         }
-        model_params.tensor_split = tensor_split_values;
     }
     
     // Load model
@@ -2090,3 +2109,136 @@ static_assert(GGML_LOG_LEVEL_INFO  == 2, "LogLevelInfo out of sync with llama.go
 static_assert(GGML_LOG_LEVEL_WARN  == 3, "LogLevelWarn out of sync with llama.go");
 static_assert(GGML_LOG_LEVEL_ERROR == 4, "LogLevelError out of sync with llama.go");
 static_assert(GGML_LOG_LEVEL_CONT  == 5, "LogLevelCont out of sync with llama.go");
+
+//
+// Model file utilities
+//
+// These operate on model files rather than on a loaded model, so most take no
+// binding state.
+//
+
+// Quantizes a GGUF file. ftype is a llama_ftype value; nthread <= 0 lets the
+// engine pick. Returns 0 on success, non-zero on failure.
+int quantize_model(const char* fname_in, const char* fname_out, int ftype, int nthread,
+                   bool allow_requantize, bool quantize_output_tensor,
+                   bool pure, bool keep_split) {
+    if (fname_in == nullptr || fname_out == nullptr) {
+        return 1;
+    }
+    llama_model_quantize_params params = llama_model_quantize_default_params();
+    params.ftype                  = (enum llama_ftype) ftype;
+    params.nthread                = nthread;
+    params.allow_requantize       = allow_requantize;
+    params.quantize_output_tensor = quantize_output_tensor;
+    params.pure                   = pure;
+    params.keep_split             = keep_split;
+    return (int) llama_model_quantize(fname_in, fname_out, &params);
+}
+
+// Reports the size a quantization would produce, without writing anything.
+// Returns 0 on success.
+int quantize_model_dry_run(const char* fname_in, int ftype, int nthread) {
+    if (fname_in == nullptr) {
+        return 1;
+    }
+    llama_model_quantize_params params = llama_model_quantize_default_params();
+    params.ftype   = (enum llama_ftype) ftype;
+    params.nthread = nthread;
+    params.dry_run = true;
+    return (int) llama_model_quantize(fname_in, fname_in, &params);
+}
+
+void save_model_to_file(void* state_ptr, const char* path) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    llama_model_save_to_file(state->model, path);
+}
+
+// Sharded ("split") GGUF paths. split_path builds the path of one shard from a
+// prefix; split_prefix recovers the prefix from a shard path. Both follow
+// snprintf-style semantics and return 0 when the input does not match the
+// expected naming scheme.
+int build_split_path(char* buf, int buf_size, const char* prefix, int split_no, int split_count) {
+    if (buf == nullptr || buf_size <= 0) {
+        return 0;
+    }
+    return llama_split_path(buf, (size_t) buf_size, prefix, split_no, split_count);
+}
+
+int build_split_prefix(char* buf, int buf_size, const char* split_path, int split_no, int split_count) {
+    if (buf == nullptr || buf_size <= 0) {
+        return 0;
+    }
+    return llama_split_prefix(buf, (size_t) buf_size, split_path, split_no, split_count);
+}
+
+// Model load modes (mmap, mlock, direct I/O). Names round-trip through
+// load_mode_from_str.
+//
+// The engine throws std::invalid_argument for an unrecognised name. A C++
+// exception crossing into cgo aborts the process, so it is caught here and
+// reported as LLAMA_LOAD_MODE_AUTO, which is the engine's own "decide for me"
+// value.
+int load_mode_from_str(const char* str) {
+    if (str == nullptr) {
+        return -1;  // LLAMA_LOAD_MODE_AUTO
+    }
+    try {
+        return (int) llama_load_mode_from_str(str);
+    } catch (const std::exception & e) {
+        fprintf(stderr, "%s: %s\n", __func__, e.what());
+        return -1;
+    }
+}
+
+int load_mode_name(int mode, char* buf, int buf_size) {
+    const char* name = llama_load_mode_name((enum llama_load_mode) mode);
+    if (name == nullptr) {
+        return -1;
+    }
+    return snprintf(buf, (size_t) buf_size, "%s", name);
+}
+
+// The name llama.cpp uses in GGUF for a well-known metadata key.
+int model_meta_key_str(int key, char* buf, int buf_size) {
+    const char* name = llama_model_meta_key_str((enum llama_model_meta_key) key);
+    if (name == nullptr) {
+        return -1;
+    }
+    return snprintf(buf, (size_t) buf_size, "%s", name);
+}
+
+int max_tensor_buft_overrides(void) {
+    return (int) llama_max_tensor_buft_overrides();
+}
+
+void backend_free(void) {
+    llama_backend_free();
+}
+
+//
+// Abort callback
+//
+// Lets a caller stop a decode that is already running on the backend, which is
+// otherwise uninterruptible. The engine polls this between graph nodes.
+
+extern "C" unsigned char goAbortCallback(void* state_ptr);
+
+static bool binding_abort_callback(void* data) {
+    return goAbortCallback(data) != 0;
+}
+
+void set_abort_callback(void* state_ptr, bool enable) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (enable) {
+        llama_set_abort_callback(state->ctx, binding_abort_callback, state_ptr);
+    } else {
+        llama_set_abort_callback(state->ctx, nullptr, nullptr);
+    }
+}
+
+static_assert(LLAMA_LOAD_MODE_AUTO       == -1, "LoadModeAuto out of sync with llama.go");
+static_assert(LLAMA_LOAD_MODE_NONE       ==  0, "LoadModeNone out of sync with llama.go");
+static_assert(LLAMA_LOAD_MODE_MMAP       ==  1, "LoadModeMmap out of sync with llama.go");
+static_assert(LLAMA_LOAD_MODE_MLOCK      ==  2, "LoadModeMlock out of sync with llama.go");
+static_assert(LLAMA_LOAD_MODE_MMAP_MLOCK ==  3, "LoadModeMmapMlock out of sync with llama.go");
+static_assert(LLAMA_LOAD_MODE_DIRECT_IO  ==  4, "LoadModeDirectIO out of sync with llama.go");

--- a/binding.h
+++ b/binding.h
@@ -251,6 +251,30 @@ bool model_is_recurrent(void* state_ptr);
 // System info
 int get_system_info(char* buf, int buf_size);
 
+// Model file utilities. quantize_model writes a requantized copy and returns 0
+// on success; quantize_model_dry_run reports the resulting size without
+// writing. The split helpers translate between a sharded-GGUF prefix and one
+// shard's path, returning 0 when the input does not match the naming scheme.
+// The *_name functions follow snprintf semantics.
+int quantize_model(const char* fname_in, const char* fname_out, int ftype, int nthread,
+                   bool allow_requantize, bool quantize_output_tensor,
+                   bool pure, bool keep_split);
+int quantize_model_dry_run(const char* fname_in, int ftype, int nthread);
+void save_model_to_file(void* state_ptr, const char* path);
+int build_split_path(char* buf, int buf_size, const char* prefix, int split_no, int split_count);
+int build_split_prefix(char* buf, int buf_size, const char* split_path, int split_no, int split_count);
+int load_mode_from_str(const char* str);
+int load_mode_name(int mode, char* buf, int buf_size);
+int model_meta_key_str(int key, char* buf, int buf_size);
+int max_tensor_buft_overrides(void);
+void backend_free(void);
+
+// Abort callback. set_abort_callback(state, true) makes the engine poll
+// goAbortCallback between graph nodes so a running decode can be stopped;
+// passing false detaches it.
+extern unsigned char goAbortCallback(void* state_ptr);
+void set_abort_callback(void* state_ptr, bool enable);
+
 // Backend capability queries. These reflect how the llama.cpp library was
 // compiled and require no loaded model.
 bool backend_supports_mmap(void);

--- a/llama.go
+++ b/llama.go
@@ -59,7 +59,16 @@ func New(model string, opts ...ModelOption) (*LLama, error) {
 	return ll, nil
 }
 
+// Free releases the model and its context. The LLama must not be used
+// afterwards.
+//
+// It also drops any token and abort callbacks registered for this model. Those
+// are keyed by the context pointer, and the allocator can hand the same address
+// to a later model, so leaving them behind would let a freed model's callbacks
+// fire for an unrelated one.
 func (l *LLama) Free() {
+	l.SetAbortCallback(nil)
+	setCallback(l.state, nil)
 	C.llama_binding_free_model(l.state)
 }
 
@@ -1588,6 +1597,190 @@ func SystemInfo() string {
 		return ""
 	}
 	return string(buf[:ret])
+}
+
+// LoadMode selects how a model file is brought into memory.
+type LoadMode int
+
+// Load modes, mirroring llama_load_mode.
+const (
+	LoadModeAuto      LoadMode = -1 // pick based on device capabilities
+	LoadModeNone      LoadMode = 0  // plain reads
+	LoadModeMmap      LoadMode = 1
+	LoadModeMlock     LoadMode = 2 // keep resident, never swapped
+	LoadModeMmapMlock LoadMode = 3
+	LoadModeDirectIO  LoadMode = 4 // bypass the page cache where supported
+)
+
+// String returns llama.cpp's name for the mode, which is also what
+// ParseLoadMode accepts.
+func (m LoadMode) String() string {
+	buf := make([]byte, 64)
+	ret := int(C.load_mode_name(C.int(m), (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+	if ret <= 0 || ret > len(buf) {
+		return fmt.Sprintf("LoadMode(%d)", int(m))
+	}
+	return string(buf[:ret])
+}
+
+// ParseLoadMode converts one of llama.cpp's load-mode names back to a
+// LoadMode. An unrecognised name yields LoadModeAuto.
+func ParseLoadMode(s string) LoadMode {
+	cs := C.CString(s)
+	defer C.free(unsafe.Pointer(cs))
+	return LoadMode(C.load_mode_from_str(cs))
+}
+
+// QuantizeOptions controls Quantize. The zero value is not useful — set at
+// least FileType.
+type QuantizeOptions struct {
+	// FileType is the llama_ftype to quantize to. Use FileTypeName to
+	// render one, and llama.cpp's quantize tool for the list of values.
+	FileType int
+	// Threads is the worker count; 0 or less lets the engine choose.
+	Threads int
+	// AllowRequantize permits quantizing tensors that are already
+	// quantized, which loses more precision than starting from f16/f32.
+	AllowRequantize bool
+	// QuantizeOutputTensor quantizes output.weight along with the rest.
+	// llama.cpp's default is true; leaving it false keeps that tensor at
+	// higher precision.
+	QuantizeOutputTensor bool
+	// Pure quantizes every tensor to FileType instead of letting the
+	// engine keep sensitive tensors at a higher precision.
+	Pure bool
+	// KeepSplit writes the same number of shards as the input had.
+	KeepSplit bool
+}
+
+// Quantize writes a requantized copy of the GGUF file at in to out.
+//
+// This is a file-level operation: it needs no loaded model, and it is the same
+// work llama.cpp's llama-quantize tool does. Expect it to take minutes and a
+// lot of memory for a large model.
+func Quantize(in, out string, opts QuantizeOptions) error {
+	cIn := C.CString(in)
+	defer C.free(unsafe.Pointer(cIn))
+	cOut := C.CString(out)
+	defer C.free(unsafe.Pointer(cOut))
+
+	ret := int(C.quantize_model(cIn, cOut, C.int(opts.FileType), C.int(opts.Threads),
+		C.bool(opts.AllowRequantize), C.bool(opts.QuantizeOutputTensor),
+		C.bool(opts.Pure), C.bool(opts.KeepSplit)))
+	if ret != 0 {
+		return fmt.Errorf("llama: failed to quantize %q to %q (%d)", in, out, ret)
+	}
+	return nil
+}
+
+// QuantizeDryRun runs the size calculation for a quantization without writing
+// anything. llama.cpp reports the projected size through the log, so pair this
+// with SetLogHandler to capture it.
+func QuantizeDryRun(in string, fileType, threads int) error {
+	cIn := C.CString(in)
+	defer C.free(unsafe.Pointer(cIn))
+
+	if ret := int(C.quantize_model_dry_run(cIn, C.int(fileType), C.int(threads))); ret != 0 {
+		return fmt.Errorf("llama: dry-run quantization of %q failed (%d)", in, ret)
+	}
+	return nil
+}
+
+// SaveModel writes the loaded model back out as a GGUF file. Its main use is
+// persisting a model after adapters or overrides have been applied.
+func (l *LLama) SaveModel(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	C.save_model_to_file(l.state, cPath)
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("llama: model was not written to %q: %w", path, err)
+	}
+	return nil
+}
+
+// SplitPath builds the filename of one shard of a sharded GGUF model, given
+// the prefix and the shard numbering. It returns "" if the arguments do not
+// produce a valid path.
+func SplitPath(prefix string, splitNo, splitCount int) string {
+	cPrefix := C.CString(prefix)
+	defer C.free(unsafe.Pointer(cPrefix))
+
+	buf := make([]byte, 1024)
+	ret := int(C.build_split_path((*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf)),
+		cPrefix, C.int(splitNo), C.int(splitCount)))
+	if ret <= 0 || ret > len(buf) {
+		return ""
+	}
+	return string(buf[:ret])
+}
+
+// SplitPrefix recovers the shared prefix from one shard's path — the inverse
+// of SplitPath. It returns "" when path does not follow the shard naming
+// scheme for the given numbering.
+func SplitPrefix(path string, splitNo, splitCount int) string {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	buf := make([]byte, 1024)
+	ret := int(C.build_split_prefix((*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf)),
+		cPath, C.int(splitNo), C.int(splitCount)))
+	if ret <= 0 || ret > len(buf) {
+		return ""
+	}
+	return string(buf[:ret])
+}
+
+// MaxTensorBuftOverrides is the largest number of tensor buffer-type overrides
+// the engine accepts.
+func MaxTensorBuftOverrides() int { return int(C.max_tensor_buft_overrides()) }
+
+// BackendFree releases llama.cpp's global backend state. Call it once at
+// process shutdown, after every model has been Freed; using any part of this
+// package afterwards is undefined.
+func BackendFree() { C.backend_free() }
+
+var (
+	abortMu        sync.RWMutex
+	abortCallbacks = map[uintptr]func() bool{}
+)
+
+// SetAbortCallback installs fn as the interrupt check for this model's
+// decodes. The engine calls it repeatedly while a graph is running, and
+// returning true aborts the computation in progress — Decode then reports
+// status 2.
+//
+// This is the only way to stop work already handed to the backend: a token
+// callback can end generation between tokens, but not during one. Use it to
+// honour a context.Context deadline:
+//
+//	model.SetAbortCallback(func() bool { return ctx.Err() != nil })
+//
+// fn runs on the engine's compute thread and is called very often, so it must
+// be cheap and safe for concurrent use. Pass nil to remove it.
+func (l *LLama) SetAbortCallback(fn func() bool) {
+	abortMu.Lock()
+	defer abortMu.Unlock()
+
+	if fn == nil {
+		delete(abortCallbacks, uintptr(l.state))
+		C.set_abort_callback(l.state, C.bool(false))
+		return
+	}
+	abortCallbacks[uintptr(l.state)] = fn
+	C.set_abort_callback(l.state, C.bool(true))
+}
+
+//export goAbortCallback
+func goAbortCallback(statePtr unsafe.Pointer) C.uchar {
+	abortMu.RLock()
+	fn := abortCallbacks[uintptr(statePtr)]
+	abortMu.RUnlock()
+
+	if fn != nil && fn() {
+		return 1
+	}
+	return 0
 }
 
 // StateSize returns the number of bytes StateData will produce for the whole

--- a/llama_test.go
+++ b/llama_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/AshkanYarmoradi/go-llama.cpp"
 	. "github.com/AshkanYarmoradi/go-llama.cpp"
@@ -1211,6 +1212,113 @@ how much is 2+2?
 			mu.Lock()
 			defer mu.Unlock()
 			Expect(count).To(Equal(afterFirst), "handler was called after being removed")
+		})
+	})
+
+	Context("Model file utilities", func() {
+		It("round-trips load mode names", func() {
+			for _, m := range []LoadMode{LoadModeNone, LoadModeMmap, LoadModeMlock, LoadModeMmapMlock, LoadModeDirectIO} {
+				name := m.String()
+				Expect(name).ToNot(BeEmpty())
+				Expect(ParseLoadMode(name)).To(Equal(m), "round trip failed for %s", name)
+			}
+			// An unrecognised name falls back to auto-detection.
+			Expect(ParseLoadMode("definitely-not-a-load-mode")).To(Equal(LoadModeAuto))
+		})
+
+		It("builds and parses sharded model paths", func() {
+			path := SplitPath("/models/llama", 2, 5)
+			Expect(path).ToNot(BeEmpty())
+			Expect(path).To(ContainSubstring("llama"))
+
+			// SplitPrefix is the inverse.
+			Expect(SplitPrefix(path, 2, 5)).To(Equal("/models/llama"))
+
+			// A path that does not follow the scheme yields nothing.
+			Expect(SplitPrefix("/models/plain.gguf", 2, 5)).To(BeEmpty())
+		})
+
+		It("reports the tensor override limit", func() {
+			Expect(MaxTensorBuftOverrides()).To(BeNumerically(">", 0))
+		})
+
+		It("reports an error for an unreadable quantization input", func() {
+			err := Quantize(filepath.Join(GinkgoT().TempDir(), "missing.gguf"),
+				filepath.Join(GinkgoT().TempDir(), "out.gguf"),
+				QuantizeOptions{FileType: 2})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("aborts a decode from the callback", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			tokens := model.Tokenize("The capital of France is", true, false)
+			Expect(tokens).ToNot(BeEmpty())
+
+			var calls int32
+			model.SetAbortCallback(func() bool {
+				atomic.AddInt32(&calls, 1)
+				return true // abort immediately
+			})
+
+			batch := NewBatch(len(tokens), 1)
+			defer batch.Free()
+			for i, tok := range tokens {
+				Expect(batch.Add(tok, int32(i), []int32{0}, i == len(tokens)-1)).To(Succeed())
+			}
+
+			// llama.cpp reports 2 for an aborted decode.
+			Expect(model.Decode(batch)).To(Equal(2))
+			Expect(atomic.LoadInt32(&calls)).To(BeNumerically(">", 0))
+
+			// With the callback removed the same batch decodes normally.
+			model.SetAbortCallback(nil)
+			model.MemoryClear(true)
+			Expect(model.Decode(batch)).To(Equal(0))
+		})
+	})
+
+	// These inputs used to abort the process: llama.cpp and the binding's own
+	// parsing both throw C++ exceptions on malformed values, and an exception
+	// crossing into cgo calls std::terminate. Each must now surface as an
+	// ordinary Go error or a documented fallback.
+	Context("Malformed input does not crash the process", func() {
+		It("falls back to auto for an unknown load mode name", func() {
+			Expect(ParseLoadMode("definitely-not-a-load-mode")).To(Equal(LoadModeAuto))
+			Expect(ParseLoadMode("")).To(Equal(LoadModeAuto))
+		})
+
+		It("ignores a non-numeric main GPU", func() {
+			model, err := New("not-existing", SetMainGPU("not-a-number"))
+			Expect(err).To(HaveOccurred())
+			Expect(model).To(BeNil())
+		})
+
+		It("ignores a non-numeric tensor split", func() {
+			model, err := New("not-existing", SetTensorSplit("a,b,c"))
+			Expect(err).To(HaveOccurred())
+			Expect(model).To(BeNil())
+		})
+
+		It("ignores a malformed logit bias", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			for _, bad := range []string{"5+notanumber", "notatoken+1", "+", "garbage"} {
+				out, err := model.Predict("The capital of France is", SetTokens(4), SetLogitBias(bad))
+				Expect(err).ToNot(HaveOccurred(), "logit bias %q", bad)
+				Expect(out).ToNot(BeEmpty())
+			}
 		})
 	})
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {


### PR DESCRIPTION
Stacked on #216 -> #215 -> #214 -> #213 -> #212 -> #211 -> #210 -> #209 -> #208 -> #207 -> #206.

The remaining group of engine APIs that operate *around* a model rather than on one — plus a class of process-killing crash that CI caught in this branch.

## C++ exceptions were aborting the process

A `throw` that reaches cgo calls `std::terminate`: the whole process dies with `SIGABRT` and **no Go error is ever returned**. Four call sites could do it.

CI caught the first one in this very branch — `ParseLoadMode("not-a-mode")` killed the test binary outright:

```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  unknown load mode: definitely-not-a-load-mode
SIGABRT: abort
signal arrived during cgo execution
```

`llama_load_mode_from_str` throws for a name it doesn't recognise (`llama.cpp:74`). It now returns `LoadModeAuto`, the engine's own "decide for me" value.

Auditing for the same shape found **three more that predate this branch**:

| Site | Trigger |
| --- | --- |
| `std::stoi(maingpu)` | `SetMainGPU("abc")` |
| `std::stof(split_arg[i])` | `SetTensorSplit("a,b")` |
| `std::stof(value_str)` | `SetLogitBias("5+notanumber")` |

Any of these would abort a caller's process on malformed input. Each is now caught, reported on stderr, and the default kept. (llama.cpp's own state and quantize entry points already have internal `try`/`catch` — I checked those rather than assuming.)

A test covers all four; three need no model.

## Abort callback

```go
model.SetAbortCallback(func() bool { return ctx.Err() != nil })
```

**The only way to stop work already handed to the backend.** A token callback ends generation *between* tokens; a single long decode — a large prompt — was uninterruptible. The engine polls this between graph nodes; an aborted `Decode` reports status `2`.

## Quantization and sharded paths

```go
llama.Quantize(in, out, llama.QuantizeOptions{FileType: ft})
llama.QuantizeDryRun(in, ft, threads)   // size only, writes nothing
llama.SplitPath("/models/llama", 2, 5)  // one shard's filename
llama.SplitPrefix(path, 2, 5)           // and back again
```

Plus `LoadMode` with names that round-trip through `ParseLoadMode`, `SaveModel`, `MaxTensorBuftOverrides`, and `BackendFree`.

## Bug fix: callbacks outlived their model

`Free` released the context but left the token callback registered, and **both callback maps are keyed by the context pointer**. The allocator can hand that address to a later model — at which point a freed model's callback fires for an unrelated one. `Free` now drops both registrations first.

## Deliberately not wrapped

- **`llama_attach_threadpool` / `llama_detach_threadpool`** take `ggml_threadpool` objects this binding doesn't expose.
- **`llama_sampler_init` / `llama_sampler_apply` / `llama_sampler_copy`** exist to implement *custom* samplers, needing a C vtable Go cannot supply.
- **`llama_opt_*`** is the training API.

## Engine APIs newly covered (11)

`llama_model_quantize`, `llama_model_quantize_default_params`, `llama_model_save_to_file`, `llama_split_path`, `llama_split_prefix`, `llama_load_mode_name`, `llama_load_mode_from_str`, `llama_model_meta_key_str`, `llama_max_tensor_buft_overrides`, `llama_backend_free`, `llama_set_abort_callback`