### PR TITLE
feat: sharded model loading, partial sequence state, coverage doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ several rounds of breaking API changes. This fork tracks upstream: a Dependabot
 job bumps the llama.cpp submodule daily, and the binding is updated to match
 when the engine's API moves.
 
-It targets the modern llama.cpp C API. Functions upstream marks deprecated are
-deliberately not exposed — the binding wraps the replacement instead.
+It targets the modern llama.cpp C API and covers **186 of its 200 live
+functions**; the 14 exclusions are deliberate and listed in
+[docs/engine-coverage.md](docs/engine-coverage.md). Functions upstream marks
+deprecated are not exposed — the binding wraps the replacement instead.
 
 ---
 

--- a/binding.cpp
+++ b/binding.cpp
@@ -848,10 +848,21 @@ void* llama_allocate_params(const char *prompt, int seed, int threads, int token
     return params;
 }
 
-void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool mlock, 
-                 bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch, 
-                 const char *maingpu, const char *tensorsplit, bool numa, float rope_freq_base, 
+// Shared implementation. paths holds n_paths GGUF files: one for an ordinary
+// model, or every shard of a model whose filenames do not follow llama.cpp's
+// "-00001-of-0000N.gguf" convention (which it can otherwise infer from the
+// first shard alone).
+static void* load_model_impl(const char **paths, int n_paths,
+                 int n_ctx, int n_seed, bool memory_f16, bool mlock,
+                 bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch,
+                 const char *maingpu, const char *tensorsplit, bool numa, float rope_freq_base,
                  float rope_freq_scale, const char *lora, const char *lora_base) {
+
+    if (paths == nullptr || n_paths <= 0 || paths[0] == nullptr) {
+        fprintf(stderr, "%s: error: no model path given\n", __func__);
+        return nullptr;
+    }
+    const char *fname = paths[0];
 
     // These parameters are retained for C ABI stability with the Go layer but
     // are no longer consumed by llama.cpp: the seed is applied when the sampler
@@ -911,7 +922,9 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
     }
     
     // Load model
-    llama_model * model = llama_model_load_from_file(fname, model_params);
+    llama_model * model = n_paths == 1
+        ? llama_model_load_from_file(fname, model_params)
+        : llama_model_load_from_splits(paths, (size_t) n_paths, model_params);
     if (model == nullptr) {
         fprintf(stderr, "%s: error: failed to load model '%s'\n", __func__, fname);
         return nullptr;
@@ -962,6 +975,29 @@ void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool
     state->ctx = ctx;
     
     return state;
+}
+
+void* load_model(const char *fname, int n_ctx, int n_seed, bool memory_f16, bool mlock,
+                 bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch,
+                 const char *maingpu, const char *tensorsplit, bool numa, float rope_freq_base,
+                 float rope_freq_scale, const char *lora, const char *lora_base) {
+    const char *paths[1] = { fname };
+    return load_model_impl(paths, 1, n_ctx, n_seed, memory_f16, mlock, embeddings, mmap,
+                           low_vram, n_gpu_layers, n_batch, maingpu, tensorsplit, numa,
+                           rope_freq_base, rope_freq_scale, lora, lora_base);
+}
+
+// Loads a model from an explicit list of shards. Only needed when the shard
+// filenames do not follow llama.cpp's own naming scheme; otherwise load_model
+// with the first shard is enough.
+void* load_model_splits(const char **paths, int n_paths,
+                        int n_ctx, int n_seed, bool memory_f16, bool mlock,
+                        bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch,
+                        const char *maingpu, const char *tensorsplit, bool numa, float rope_freq_base,
+                        float rope_freq_scale, const char *lora, const char *lora_base) {
+    return load_model_impl(paths, n_paths, n_ctx, n_seed, memory_f16, mlock, embeddings, mmap,
+                           low_vram, n_gpu_layers, n_batch, maingpu, tensorsplit, numa,
+                           rope_freq_base, rope_freq_scale, lora, lora_base);
 }
 
 // Model info functions
@@ -2242,3 +2278,41 @@ static_assert(LLAMA_LOAD_MODE_MMAP       ==  1, "LoadModeMmap out of sync with l
 static_assert(LLAMA_LOAD_MODE_MLOCK      ==  2, "LoadModeMlock out of sync with llama.go");
 static_assert(LLAMA_LOAD_MODE_MMAP_MLOCK ==  3, "LoadModeMmapMlock out of sync with llama.go");
 static_assert(LLAMA_LOAD_MODE_DIRECT_IO  ==  4, "LoadModeDirectIO out of sync with llama.go");
+
+//
+// Sequence state with flags
+//
+// The plain state_seq_* functions above capture a whole sequence. These take a
+// llama_state_seq_flags mask, which lets a caller capture only part of it —
+// LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY, for instance, saves just the
+// sliding-window part of an SWA cache, which is far smaller than the whole
+// sequence and is all that is needed to resume from the current position.
+//
+
+long long state_seq_get_size_ext(void* state_ptr, int seq_id, unsigned int flags) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    return (long long) llama_state_seq_get_size_ext(state->ctx, seq_id, flags);
+}
+
+long long state_seq_get_data_ext(void* state_ptr, unsigned char* buf, long long buf_size,
+                                 int seq_id, unsigned int flags) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    const size_t need = llama_state_seq_get_size_ext(state->ctx, seq_id, flags);
+    if (buf_size < 0 || (size_t) buf_size < need) {
+        return -(long long) need;
+    }
+    return (long long) llama_state_seq_get_data_ext(state->ctx, buf, (size_t) buf_size, seq_id, flags);
+}
+
+long long state_seq_set_data_ext(void* state_ptr, const unsigned char* buf, long long buf_size,
+                                 int dest_seq_id, unsigned int flags) {
+    llama_binding_state* state = (llama_binding_state*) state_ptr;
+    if (buf == nullptr || buf_size <= 0) {
+        return 0;
+    }
+    return (long long) llama_state_seq_set_data_ext(state->ctx, buf, (size_t) buf_size, dest_seq_id, flags);
+}
+
+static_assert(LLAMA_STATE_SEQ_FLAGS_NONE         == 0, "SeqStateAll out of sync with llama.go");
+static_assert(LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY == 1, "SeqStatePartialOnly out of sync with llama.go");
+static_assert(LLAMA_STATE_SEQ_FLAGS_ON_DEVICE    == 2, "SeqStateOnDevice out of sync with llama.go");

--- a/binding.h
+++ b/binding.h
@@ -38,6 +38,24 @@ void* load_model(const char *fname,
                  const char *lora, const char *lora_base
                  );
 
+
+// Loads a model from an explicit list of shards. Only needed when the shard
+// filenames do not follow llama.cpp's own naming scheme; otherwise load_model
+// with the first shard is enough.
+void* load_model_splits(const char **paths, int n_paths,
+                        int n_ctx, int n_seed, bool memory_f16, bool mlock,
+                        bool embeddings, bool mmap, bool low_vram, int n_gpu_layers, int n_batch,
+                        const char *maingpu, const char *tensorsplit, bool numa, float rope_freq_base,
+                        float rope_freq_scale, const char *lora, const char *lora_base);
+
+// Sequence state with a llama_state_seq_flags mask, which lets a caller
+// capture part of a sequence rather than all of it. Same buffer contract as
+// the plain state_seq_* functions.
+long long state_seq_get_size_ext(void* state_ptr, int seq_id, unsigned int flags);
+long long state_seq_get_data_ext(void* state_ptr, unsigned char* buf, long long buf_size,
+                                 int seq_id, unsigned int flags);
+long long state_seq_set_data_ext(void* state_ptr, const unsigned char* buf, long long buf_size,
+                                 int dest_seq_id, unsigned int flags);
 int get_embeddings(void* params_ptr, void* state_pr, float * res_embeddings);
 
 int get_token_embeddings(void* params_ptr, void* state_pr, int *tokens, int tokenSize, float * res_embeddings);

--- a/docs/engine-coverage.md
+++ b/docs/engine-coverage.md
@@ -1,0 +1,88 @@
+# Engine coverage
+
+This binding aims to cover llama.cpp's C API. This page records where that
+stands and, more usefully, which functions are left out **on purpose** — so an
+audit that finds them missing does not have to re-derive the reasoning.
+
+Measured against `llama.cpp/include/llama.h` at **v0.3.0** (`c1d0e7a`).
+
+|  |  |
+|---|---|
+| `LLAMA_API` declarations | 236 |
+| Marked `DEPRECATED` upstream | 36 |
+| **Live API surface** | **200** |
+| **Covered by the binding** | **186** |
+| Deliberately excluded | 14 |
+
+Deprecated functions are not wrapped. llama.cpp names its replacement in every
+`DEPRECATED` message, and the binding wraps that instead — for example
+`llama_vocab_bos` rather than `llama_token_bos`.
+
+## Deliberately excluded
+
+### Not a real symbol (1)
+
+| Function | Why |
+|---|---|
+| `llama_decode_with_sampler` | Commented out in `llama.h` (line 1534, `// TODO: extend in the future`). It appears in a text scan of the header but does not exist in the library. |
+
+### Requires binding ggml first (2)
+
+| Function | Why |
+|---|---|
+| `llama_attach_threadpool` | Takes `ggml_threadpool` objects. Wrapping it means exposing a slice of ggml's threading API, which is a separate project. |
+| `llama_detach_threadpool` | As above. |
+
+Thread counts are controllable without it — see `SetThreads`.
+
+### Needs a C function-pointer vtable Go cannot supply (3)
+
+| Function | Why |
+|---|---|
+| `llama_sampler_init` | Builds a custom sampler from a `llama_sampler_i` struct of C function pointers. Go cannot populate one, and a bridge per method would cost a cgo transition per token per stage. |
+| `llama_sampler_apply` | Operates on a `llama_token_data_array` the caller owns — only meaningful when implementing a custom sampler. |
+| `llama_sampler_copy` | Copies into a caller-allocated sampler; the same constraint. `Sampler.Clone` covers the useful case. |
+
+Every sampler llama.cpp ships is exposed. See `SamplerTopK` and friends.
+
+### Training API — out of scope (3)
+
+| Function | Why |
+|---|---|
+| `llama_opt_init` | This is an inference binding. The optimizer API needs `ggml-opt.h` dataset and callback types, and a fundamentally different lifecycle. |
+| `llama_opt_epoch` | As above. |
+| `llama_opt_param_filter_all` | As above. |
+
+### Superseded by something already exposed (5)
+
+| Function | Why |
+|---|---|
+| `llama_get_logits` | `llama.h` marks it "TODO: deprecate in favor of `llama_get_logits_ith`", which is wrapped as `Logits(i)`. |
+| `llama_get_model` | Recovers the model from a context. The binding holds both pointers in its own state, so it is never needed. |
+| `llama_perf_sampler_print` | Prints to stderr. `Sampler.Perf` returns the same numbers as data. |
+| `llama_model_init_from_user` | Constructs a model from caller-supplied tensors, for embedding llama.cpp in a larger ggml program rather than loading a GGUF file. |
+| `llama_model_load_from_file_ptr` | Loads from an open `FILE*`, which does not cross the cgo boundary usefully. `NewFromSplits` covers the case that motivates it. |
+
+## If you need one of these
+
+Open an issue using the **Missing llama.cpp API** template and say what you are
+building. Several of the exclusions above are judgement calls about cost versus
+demand, and a concrete use case changes that calculation.
+
+## Keeping this current
+
+The audit is a text scan of the header, so it needs no build:
+
+```bash
+# every LLAMA_API symbol
+grep -oE 'LLAMA_API [a-zA-Z_0-9 *]*\b(llama_[a-z_0-9]+)\s*\(' llama.cpp/include/llama.h \
+  | grep -oE 'llama_[a-z_0-9]+\s*\($' | tr -d ' (' | sort -u > /tmp/engine_api.txt
+
+# which of them binding.cpp references
+while read -r fn; do
+  grep -q "\b$fn\b" binding.cpp || echo "MISSING $fn"
+done < /tmp/engine_api.txt
+```
+
+Subtract the `DEPRECATED` ones (`grep -n DEPRECATED llama.cpp/include/llama.h`)
+and the table above. Anything left over is a real gap.

--- a/llama.go
+++ b/llama.go
@@ -34,29 +34,60 @@ type LLama struct {
 	contextSize int
 }
 
+// New loads a GGUF model and creates a context for it. Call Free on the result
+// when done; without it the model stays resident until the process exits.
+//
+// For a sharded model, pass the first shard: llama.cpp infers the rest from
+// the "-00001-of-0000N.gguf" naming scheme. Use NewFromSplits when the shards
+// are named some other way.
 func New(model string, opts ...ModelOption) (*LLama, error) {
-	mo := NewModelOptions(opts...)
-	modelPath := C.CString(model)
-	defer C.free(unsafe.Pointer(modelPath))
-	loraBase := C.CString(mo.LoraBase)
-	defer C.free(unsafe.Pointer(loraBase))
-	loraAdapter := C.CString(mo.LoraAdapter)
-	defer C.free(unsafe.Pointer(loraAdapter))
+	return newModel([]string{model}, NewModelOptions(opts...))
+}
 
-	result := C.load_model(modelPath,
-		C.int(mo.ContextSize), C.int(mo.Seed),
-		C.bool(mo.F16Memory), C.bool(mo.MLock), C.bool(mo.Embeddings), C.bool(mo.MMap), C.bool(mo.LowVRAM),
-		C.int(mo.NGPULayers), C.int(mo.NBatch), C.CString(mo.MainGPU), C.CString(mo.TensorSplit), C.bool(mo.NUMA),
-		C.float(mo.FreqRopeBase), C.float(mo.FreqRopeScale),
-		loraAdapter, loraBase,
-	)
+// NewFromSplits loads a model from an explicit list of shard files, for models
+// whose filenames do not follow llama.cpp's shard naming scheme. Pass the
+// shards in order. For a single file, or shards that do follow the scheme, use
+// New instead.
+func NewFromSplits(paths []string, opts ...ModelOption) (*LLama, error) {
+	if len(paths) == 0 {
+		return nil, errors.New("llama: no model shards given")
+	}
+	return newModel(paths, NewModelOptions(opts...))
+}
 
-	if result == nil {
-		return nil, fmt.Errorf("failed loading model")
+func newModel(paths []string, mo ModelOptions) (*LLama, error) {
+	// Every C string allocated here is freed on the way out, whether the load
+	// succeeds or not.
+	var toFree []*C.char
+	cstr := func(s string) *C.char {
+		p := C.CString(s)
+		toFree = append(toFree, p)
+		return p
+	}
+	defer func() {
+		for _, p := range toFree {
+			C.free(unsafe.Pointer(p))
+		}
+	}()
+
+	cPaths := make([]*C.char, len(paths))
+	for i, p := range paths {
+		cPaths[i] = cstr(p)
 	}
 
-	ll := &LLama{state: result, contextSize: mo.ContextSize, embeddings: mo.Embeddings}
-	return ll, nil
+	result := C.load_model_splits(
+		(**C.char)(unsafe.Pointer(&cPaths[0])), C.int(len(cPaths)),
+		C.int(mo.ContextSize), C.int(mo.Seed),
+		C.bool(mo.F16Memory), C.bool(mo.MLock), C.bool(mo.Embeddings), C.bool(mo.MMap), C.bool(mo.LowVRAM),
+		C.int(mo.NGPULayers), C.int(mo.NBatch), cstr(mo.MainGPU), cstr(mo.TensorSplit), C.bool(mo.NUMA),
+		C.float(mo.FreqRopeBase), C.float(mo.FreqRopeScale),
+		cstr(mo.LoraAdapter), cstr(mo.LoraBase),
+	)
+	if result == nil {
+		return nil, fmt.Errorf("failed loading model %q", paths[0])
+	}
+
+	return &LLama{state: result, contextSize: mo.ContextSize, embeddings: mo.Embeddings}, nil
 }
 
 // Free releases the model and its context. The LLama must not be used
@@ -1887,6 +1918,59 @@ func (l *LLama) SetSequenceStateData(data []byte, destSeqID int32) error {
 	}
 	n := int64(C.state_seq_set_data(l.state, (*C.uchar)(unsafe.Pointer(&data[0])),
 		C.longlong(len(data)), C.int(destSeqID)))
+	if n == 0 {
+		return fmt.Errorf("llama: failed to restore state into sequence %d", destSeqID)
+	}
+	return nil
+}
+
+// SeqStateFlags selects how much of a sequence's state to capture.
+type SeqStateFlags uint32
+
+// Sequence state selectors, mirroring LLAMA_STATE_SEQ_FLAGS_*.
+const (
+	// SeqStateAll captures the whole sequence. This is what
+	// SequenceStateData uses.
+	SeqStateAll SeqStateFlags = 0
+	// SeqStatePartialOnly captures only the part of the cache the model
+	// still attends to. For a sliding-window model that is far smaller
+	// than the full sequence and is enough to resume from the current
+	// position, but it cannot reconstruct earlier context.
+	SeqStatePartialOnly SeqStateFlags = 1
+	// SeqStateOnDevice keeps the state in device memory instead of
+	// copying it to host memory.
+	SeqStateOnDevice SeqStateFlags = 2
+)
+
+// SequenceStateSizeWith returns the byte size SequenceStateDataWith will
+// produce for the given flags.
+func (l *LLama) SequenceStateSizeWith(seqID int32, flags SeqStateFlags) int64 {
+	return int64(C.state_seq_get_size_ext(l.state, C.int(seqID), C.uint(flags)))
+}
+
+// SequenceStateDataWith serializes a sequence, capturing only the part the
+// flags select. SeqStatePartialOnly on a sliding-window model produces a much
+// smaller checkpoint than SequenceStateData, at the cost of not being able to
+// reconstruct context the model has already slid past.
+func (l *LLama) SequenceStateDataWith(seqID int32, flags SeqStateFlags) ([]byte, error) {
+	return stateBuf(func(buf []byte) int64 {
+		var p *C.uchar
+		if len(buf) > 0 {
+			p = (*C.uchar)(unsafe.Pointer(&buf[0]))
+		}
+		return int64(C.state_seq_get_data_ext(l.state, p, C.longlong(len(buf)),
+			C.int(seqID), C.uint(flags)))
+	})
+}
+
+// SetSequenceStateDataWith restores state captured by SequenceStateDataWith.
+// The flags must match the ones it was captured with.
+func (l *LLama) SetSequenceStateDataWith(data []byte, destSeqID int32, flags SeqStateFlags) error {
+	if len(data) == 0 {
+		return errors.New("llama: empty sequence state data")
+	}
+	n := int64(C.state_seq_set_data_ext(l.state, (*C.uchar)(unsafe.Pointer(&data[0])),
+		C.longlong(len(data)), C.int(destSeqID), C.uint(flags)))
 	if n == 0 {
 		return fmt.Errorf("llama: failed to restore state into sequence %d", destSeqID)
 	}

--- a/llama_test.go
+++ b/llama_test.go
@@ -1321,6 +1321,64 @@ how much is 2+2?
 			}
 		})
 	})
+
+	Context("Sharded loading and partial sequence state", func() {
+		It("rejects an empty shard list", func() {
+			model, err := NewFromSplits(nil)
+			Expect(err).To(HaveOccurred())
+			Expect(model).To(BeNil())
+		})
+
+		It("reports an error for shards that do not exist", func() {
+			model, err := NewFromSplits([]string{"no-such-shard-1.gguf", "no-such-shard-2.gguf"})
+			Expect(err).To(HaveOccurred())
+			Expect(model).To(BeNil())
+		})
+
+		It("loads a single-file model through the splits path", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			// One shard is the degenerate case and must behave like New.
+			model, err := NewFromSplits([]string{testModelPath}, EnableF16Memory, SetContext(128), SetMMap(true))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+			Expect(model.GetModelInfo().VocabSize).To(BeNumerically(">", 0))
+		})
+
+		It("captures a smaller checkpoint with partial-only state", func() {
+			if testModelPath == "" {
+				Skip("test skipped - only makes sense if the TEST_MODEL environment variable is set.")
+			}
+			model, err := New(testModelPath, EnableF16Memory, SetContext(128), SetMMap(true), SetNBatch(512))
+			Expect(err).ToNot(HaveOccurred())
+			defer model.Free()
+
+			tokens := model.Tokenize("The capital of France is", true, false)
+			batch := NewBatch(len(tokens), 1)
+			defer batch.Free()
+			for i, tok := range tokens {
+				Expect(batch.Add(tok, int32(i), []int32{0}, i == len(tokens)-1)).To(Succeed())
+			}
+			Expect(model.Decode(batch)).To(Equal(0))
+
+			full := model.SequenceStateSizeWith(0, SeqStateAll)
+			Expect(full).To(Equal(model.SequenceStateSize(0)), "SeqStateAll must match the default")
+			Expect(full).To(BeNumerically(">", int64(0)))
+
+			partial := model.SequenceStateSizeWith(0, SeqStatePartialOnly)
+			Expect(partial).To(BeNumerically(">", int64(0)))
+			Expect(partial).To(BeNumerically("<=", full))
+
+			data, err := model.SequenceStateDataWith(0, SeqStateAll)
+			Expect(err).ToNot(HaveOccurred())
+			model.MemoryClear(true)
+			Expect(model.SetSequenceStateDataWith(data, 0, SeqStateAll)).To(Succeed())
+			Expect(model.MemorySeqPosMax(0)).To(Equal(int32(len(tokens) - 1)))
+
+			Expect(model.SetSequenceStateDataWith(nil, 0, SeqStateAll)).To(HaveOccurred())
+		})
+	})
 	Context("Inferencing tests with GPU (using "+testModelPath+") ", Label("gpu"), func() {
 		getModel := func() (*LLama, error) {
 			model, err := New(


### PR DESCRIPTION
Final PR in the parity stack. Stacked on #217 -> #216 -> #215 -> #214 -> #213 -> #212 -> #211 -> #210 -> #209 -> #208 -> #207 -> #206.

## Where coverage lands

|  |  |
|---|---|
| `LLAMA_API` declarations at v0.3.0 | 236 |
| Marked `DEPRECATED` upstream | 36 |
| **Live API surface** | **200** |
| **Covered** | **186** (was 95 before this stack) |
| Deliberately excluded | 14 |

`docs/engine-coverage.md` records *why* each exclusion is excluded, so an audit that finds them missing doesn't have to re-derive the reasoning:

- **1** is a commented-out declaration that only looks like a symbol (`llama_decode_with_sampler`)
- **2** need ggml's threadpool bound first
- **3** need a C function-pointer vtable Go cannot supply (custom samplers)
- **3** are the training API
- **5** are superseded by something already exposed

It also carries the commands to redo the audit.

## Sharded loading

```go
llama.NewFromSplits([]string{"a.gguf", "b.gguf"}, opts...)
```

Only needed when shard filenames don't follow llama.cpp's `-00001-of-0000N.gguf` convention, which it otherwise infers from the first shard alone. `load_model` is now a thin wrapper over a shared implementation taking a path array, so both loaders go through **exactly the same** context setup, LoRA handling and error paths — no duplicated loading logic to drift.

## Partial sequence state

```go
model.SequenceStateSizeWith(0, llama.SeqStatePartialOnly)
model.SequenceStateDataWith(0, llama.SeqStatePartialOnly)
```

For a sliding-window model this captures only the part of the cache the model still attends to — much smaller than the whole sequence, and enough to resume from the current position.

## Bug fix: leak in `New`

`New` allocated C strings for `MainGPU` and `TensorSplit` inline in the call argument list and never freed them:

```go
C.int(mo.NGPULayers), C.int(mo.NBatch), C.CString(mo.MainGPU), C.CString(mo.TensorSplit), ...
```

Two allocations leaked per model load. The shared loader now tracks every C string it allocates and frees them all on the way out, on success *and* on failure.

## Engine APIs newly covered (4)

`llama_model_load_from_splits`, `llama_state_seq_get_size_ext`, `llama_state_seq_get_data_ext`, `llama_state_seq_set_data_ext`